### PR TITLE
Make plugin compatible with Paper 1.21

### DIFF
--- a/RandomEvents/plugin.yml
+++ b/RandomEvents/plugin.yml
@@ -1,7 +1,7 @@
 name: RandomEvents
 main: com.adri1711.randomevents.RandomEvents
-version: 2.9.4
-api-version: 1.13
+version: 2.9.5
+api-version: 1.21
 depend: [Lib1711]
 softdepend: [CrackShot, PlaceholderAPI, WorldEdit, WorldGuard, Multiworld, Multiverse-Core, NametagEdit, LibsDisguises, NoteBlockAPI, Citizens]
 commands:

--- a/RandomEvents_Quests/plugin.yml
+++ b/RandomEvents_Quests/plugin.yml
@@ -1,4 +1,5 @@
 name: RandomEventsQuests
 main: com.adri1711.randomeventsquests.RandomEventsQuests
-version: 1.0
+version: 1.1
+api-version: 1.21
 depend: [Quests,RandomEvents]


### PR DESCRIPTION
## Summary
- update RandomEvents api-version
- update RandomEventsQuests api-version

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848b053864c8330bd01c1512e0f898e