### PR TITLE
Fix JSON serialization without external API

### DIFF
--- a/RandomEvents/src/com/adri1711/randomevents/util/UtilidadesJson.java
+++ b/RandomEvents/src/com/adri1711/randomevents/util/UtilidadesJson.java
@@ -10,14 +10,18 @@ import com.adri1711.randomevents.match.WaterDropStep;
 import com.adri1711.randomevents.match.schedule.Schedule;
 import com.adri1711.randomevents.match.utils.BannedPlayers;
 import com.adri1711.randomevents.match.utils.InventoryPers;
+import com.adri1711.randomevents.json.GsonFactory;
+import com.google.gson.Gson;
 
 public class UtilidadesJson {
+
+       private static final Gson GSON = GsonFactory.getPrettyGson();
 
 	public static String fromMatchToJSON(RandomEvents plugin, Match match) {
 		String resultado = null;
 
-		try {
-			resultado = plugin.getApi().toJson(match);
+                try {
+                        resultado = GSON.toJson(match);
 
 			// JsonSerializerDeserializer<BossMatch> jsonSerializer = new
 			// JsonSerializerDeserializer<BossMatch>();
@@ -32,9 +36,9 @@ public class UtilidadesJson {
 	}
 
 	public static Match fromJSONToMatch(RandomEvents plugin, BufferedReader br) {
-		Match match = null;
-		try {
-			match = (Match) plugin.getApi().fromJson(br, Match.class);
+                Match match = null;
+                try {
+                        match = GSON.fromJson(br, Match.class);
 			UtilsRandomEvents.normalizaColorsMatch(match);
 
 		} catch (Exception e) {
@@ -47,8 +51,8 @@ public class UtilidadesJson {
 	public static String fromWDToJSON(RandomEvents plugin, WaterDropStep match) {
 		String resultado = null;
 
-		try {
-			resultado = plugin.getApi().toJson(match);
+                try {
+                        resultado = GSON.toJson(match);
 
 			// JsonSerializerDeserializer<BossMatch> jsonSerializer = new
 			// JsonSerializerDeserializer<BossMatch>();
@@ -63,9 +67,9 @@ public class UtilidadesJson {
 	}
 
 	public static WaterDropStep fromJSONToWD(RandomEvents plugin, BufferedReader br) {
-		WaterDropStep match = null;
-		try {
-			match = (WaterDropStep) plugin.getApi().fromJson(br, WaterDropStep.class);
+                WaterDropStep match = null;
+                try {
+                        match = GSON.fromJson(br, WaterDropStep.class);
 			UtilsRandomEvents.normalizaColorsWaterDrop(match);
 
 		} catch (Exception e) {
@@ -78,8 +82,8 @@ public class UtilidadesJson {
 	public static String fromKitToJSON(RandomEvents plugin, Kit match) {
 		String resultado = null;
 
-		try {
-			resultado = plugin.getApi().toJson(match);
+                try {
+                        resultado = GSON.toJson(match);
 
 			// JsonSerializerDeserializer<BossMatch> jsonSerializer = new
 			// JsonSerializerDeserializer<BossMatch>();
@@ -94,9 +98,9 @@ public class UtilidadesJson {
 	}
 
 	public static Kit fromJSONToKit(RandomEvents plugin, BufferedReader br) {
-		Kit match = null;
-		try {
-			match = (Kit) plugin.getApi().fromJson(br, Kit.class);
+                Kit match = null;
+                try {
+                        match = GSON.fromJson(br, Kit.class);
 			UtilsRandomEvents.normalizaColorsKit(match);
 
 		} catch (Exception e) {
@@ -110,8 +114,8 @@ public class UtilidadesJson {
 	public static String fromScheduleToJSON(RandomEvents plugin, Schedule match) {
 		String resultado = null;
 
-		try {
-			resultado = plugin.getApi().toJson(match);
+                try {
+                        resultado = GSON.toJson(match);
 
 			// JsonSerializerDeserializer<BossMatch> jsonSerializer = new
 			// JsonSerializerDeserializer<BossMatch>();
@@ -126,9 +130,9 @@ public class UtilidadesJson {
 	}
 
 	public static Schedule fromJSONToSchedule(RandomEvents plugin, BufferedReader br) {
-		Schedule match = null;
-		try {
-			match = (Schedule) plugin.getApi().fromJson(br, Schedule.class);
+                Schedule match = null;
+                try {
+                        match = GSON.fromJson(br, Schedule.class);
 
 		} catch (Exception e) {
 			plugin.getLoggerP().info(e.getMessage());
@@ -140,8 +144,8 @@ public class UtilidadesJson {
 	public static String fromInventoryToJSON(RandomEvents plugin, InventoryPers inventory) {
 		String resultado = null;
 
-		try {
-			resultado = plugin.getApi().toJson(inventory);
+                try {
+                        resultado = GSON.toJson(inventory);
 
 			// JsonSerializerDeserializer<BossMatch> jsonSerializer = new
 			// JsonSerializerDeserializer<BossMatch>();
@@ -156,9 +160,9 @@ public class UtilidadesJson {
 	}
 
 	public static InventoryPers fromJSONToInventory(RandomEvents plugin, BufferedReader br) {
-		InventoryPers inventory = null;
-		try {
-			inventory = (InventoryPers) plugin.getApi().fromJson(br, InventoryPers.class);
+                InventoryPers inventory = null;
+                try {
+                        inventory = GSON.fromJson(br, InventoryPers.class);
 
 		} catch (Exception e) {
 			plugin.getLoggerP().info(e.getMessage());
@@ -170,8 +174,8 @@ public class UtilidadesJson {
 	public static String fromBannedToJSON(RandomEvents plugin, BannedPlayers bp) {
 		String resultado = null;
 
-		try {
-			resultado = plugin.getApi().toJson(bp);
+                try {
+                        resultado = GSON.toJson(bp);
 
 		} catch (Exception e) {
 			plugin.getLoggerP().info(e.getMessage());
@@ -182,9 +186,9 @@ public class UtilidadesJson {
 	}
 
 	public static BannedPlayers fromJSONToBanned(RandomEvents plugin, BufferedReader br) {
-		BannedPlayers bp = null;
-		try {
-			bp = (BannedPlayers) plugin.getApi().fromJson(br, BannedPlayers.class);
+                BannedPlayers bp = null;
+                try {
+                        bp = GSON.fromJson(br, BannedPlayers.class);
 
 		} catch (Exception e) {
 			plugin.getLoggerP().info(e.getMessage());
@@ -196,8 +200,8 @@ public class UtilidadesJson {
 	public static String fromDisabledPlayersToJSON(RandomEvents plugin, PlayersDisabled bp) {
 		String resultado = null;
 
-		try {
-			resultado = plugin.getApi().toJson(bp);
+                try {
+                        resultado = GSON.toJson(bp);
 
 		} catch (Exception e) {
 			plugin.getLoggerP().info(e.getMessage());
@@ -207,9 +211,9 @@ public class UtilidadesJson {
 
 	}
 	public static PlayersDisabled fromJSONToDisabledPlayers(RandomEvents plugin, BufferedReader br) {
-		PlayersDisabled bp = null;
-		try {
-			bp = (PlayersDisabled) plugin.getApi().fromJson(br, PlayersDisabled.class);
+                PlayersDisabled bp = null;
+                try {
+                        bp = GSON.fromJson(br, PlayersDisabled.class);
 
 		} catch (Exception e) {
 			plugin.getLoggerP().info(e.getMessage());


### PR DESCRIPTION
## Summary
- stop using external API to serialize data
- fall back to GsonFactory inside UtilidadesJson to avoid null errors

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6848d0bbcae48330b33d076bd313f1f0