### PR TITLE
Handle missing matches in begin command

### DIFF
--- a/RandomEvents/src/com/adri1711/randomevents/commands/ComandosExecutor.java
+++ b/RandomEvents/src/com/adri1711/randomevents/commands/ComandosExecutor.java
@@ -471,24 +471,35 @@ public class ComandosExecutor {
 
 	}
 
-	public void forceRandomEvent(RandomEvents plugin, Player player) {
-		if (plugin.getMatchActive() == null) {
-			plugin.setForzado(Boolean.TRUE);
-			plugin.setMatchActive(
-					UtilsRandomEvents.escogeMatchActiveAleatoria(plugin, plugin.getMatchesAvailable(), true));
-			try {
-				Bukkit.getPluginManager().callEvent(new ReventSpawnEvent(plugin.getMatchActive(), true));
-			} catch (Exception e) {
-				plugin.getLoggerP().info("[RandomEvents] WARN :: Couldnt fire the ReventSpawnEvent.");
-			}
-			if (player != null)
-				player.sendMessage(plugin.getLanguage().getTagPlugin() + plugin.getLanguage().getMatchBeginSoon());
-		} else {
-			if (player != null)
-				player.sendMessage(plugin.getLanguage().getTagPlugin() + plugin.getLanguage().getMatchBegun());
-		}
+       public void forceRandomEvent(RandomEvents plugin, Player player) {
+               if (plugin.getMatchActive() == null) {
+                       MatchActive mActive = UtilsRandomEvents.escogeMatchActiveAleatoria(plugin,
+                                       plugin.getMatchesAvailable(), true);
 
-	}
+                       if (mActive == null) {
+                               if (player != null) {
+                                       player.sendMessage(plugin.getLanguage().getTagPlugin()
+                                                       + plugin.getLanguage().getInvalidInput());
+                               }
+                               return;
+                       }
+
+                       plugin.setForzado(Boolean.TRUE);
+                       plugin.setMatchActive(mActive);
+                       try {
+                               Bukkit.getPluginManager().callEvent(new ReventSpawnEvent(plugin.getMatchActive(), true));
+                       } catch (Exception e) {
+                               plugin.getLoggerP().info("[RandomEvents] WARN :: Couldnt fire the ReventSpawnEvent.");
+                       }
+                       if (player != null)
+                               player.sendMessage(
+                                               plugin.getLanguage().getTagPlugin() + plugin.getLanguage().getMatchBeginSoon());
+               } else {
+                       if (player != null)
+                               player.sendMessage(plugin.getLanguage().getTagPlugin() + plugin.getLanguage().getMatchBegun());
+               }
+
+       }
 
 	public void forceTournamentRandomEvent(RandomEvents plugin, Player player) {
 		if (plugin.getTournamentActive() == null) {

--- a/RandomEvents/src/com/adri1711/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/adri1711/randomevents/util/UtilsRandomEvents.java
@@ -1290,21 +1290,29 @@ public class UtilsRandomEvents {
 		return p;
 	}
 
-	public static MatchActive escogeMatchActiveAleatoria(RandomEvents plugin, List<Match> matches, Boolean forzada) {
-		Match m = null;
-		List<Match> matchAvailables = new ArrayList<Match>();
+       public static MatchActive escogeMatchActiveAleatoria(RandomEvents plugin, List<Match> matches, Boolean forzada) {
+               if (matches == null || matches.isEmpty()) {
+                       return null;
+               }
 
-		for (Match match : matches) {
-			if (match.getEnabled() == null || match.getEnabled()) {
-				matchAvailables.add(match);
-			}
-		}
-		m = matches.get(plugin.getRandom().nextInt(matchAvailables.size()));
+               List<Match> matchAvailables = new ArrayList<Match>();
 
-		MatchActive matchActive = new MatchActive(m, plugin, forzada);
+               for (Match match : matches) {
+                       if (match.getEnabled() == null || match.getEnabled()) {
+                               matchAvailables.add(match);
+                       }
+               }
 
-		return matchActive;
-	}
+               if (matchAvailables.isEmpty()) {
+                       return null;
+               }
+
+               Match m = matchAvailables.get(plugin.getRandom().nextInt(matchAvailables.size()));
+
+               MatchActive matchActive = new MatchActive(m, plugin, forzada);
+
+               return matchActive;
+       }
 
 	public static void borraInventario(Player player, RandomEvents plugin) {
 		if (plugin.getReventConfig().isInventoryManagement()


### PR DESCRIPTION
## Summary
- avoid InvocationTargetException when running `/revent begin`
- check for empty match lists before starting events

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_6848d3547a348330b2a177e873fdcb89