### PR TITLE
Fix particle config parse error

### DIFF
--- a/RandomEvents/src/com/adri1711/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/adri1711/randomevents/match/MatchActive.java
@@ -631,8 +631,8 @@ public class MatchActive {
 			}
 
 		}
-		UtilsRandomEvents.spawnParticles(Particle1711.valueOf(plugin.getReventConfig().getParticleDeath()), plugin,
-				lastLocation);
+                UtilsRandomEvents.spawnParticles(Particle1711.safeValueOf(plugin.getReventConfig().getParticleDeath()), plugin,
+                                lastLocation);
 		if (comprueba)
 			compruebaPartida();
 
@@ -2481,11 +2481,11 @@ public class MatchActive {
 			task = new BukkitRunnable() {
 				public void run() {
 
-					if (getPlayerHandler().getPlayerContador() != null) {
-						UtilsRandomEvents.spawnParticles(
-								Particle1711.valueOf(plugin.getReventConfig().getParticleTNTTag()), plugin,
-								getPlayerHandler().getPlayerContador().getLocation());
-					}
+                                        if (getPlayerHandler().getPlayerContador() != null) {
+                                                UtilsRandomEvents.spawnParticles(
+                                                                Particle1711.safeValueOf(plugin.getReventConfig().getParticleTNTTag()), plugin,
+                                                                getPlayerHandler().getPlayerContador().getLocation());
+                                        }
 				}
 			};
 			task.runTaskTimer(plugin, 0, 5L);

--- a/RandomEvents/src/com/adri1711/util/enums/Particle1711.java
+++ b/RandomEvents/src/com/adri1711/util/enums/Particle1711.java
@@ -2,5 +2,16 @@ package com.adri1711.util.enums;
 
 public enum Particle1711 {
     DEFAULT,
-    REDSTONE
+    REDSTONE;
+
+    public static Particle1711 safeValueOf(String name) {
+        if (name == null) {
+            return DEFAULT;
+        }
+        try {
+            return Particle1711.valueOf(name.trim().toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return DEFAULT;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `safeValueOf` helper to Particle1711 enum
- use safeValueOf for particle configs so invalid names fallback to `DEFAULT`

## Testing
- `gradle test --console plain`

------
https://chatgpt.com/codex/tasks/task_e_6848dfe725b08330ac1fc9dbd244f535