### PR TITLE
Fix kitedit without args

### DIFF
--- a/RandomEvents/src/com/adri1711/randomevents/commands/ComandosEnum.java
+++ b/RandomEvents/src/com/adri1711/randomevents/commands/ComandosEnum.java
@@ -34,9 +34,11 @@ public enum ComandosEnum {
 	
 	CMD_LIST("list", 1, "randomevent.admin.matches", "getMenuMatches", "showRandomEvents", true, true),
 	
-	CMD_KITS("kits", 1, "randomevent.kits", "getKitsCmd", "showKits", true, true),
-	
-	CMD_KITS_EDIT("kitedit", 2, "randomevent.kits.edit", "getKitsEditCmd", "editKit", true, true),
+        CMD_KITS("kits", 1, "randomevent.kits", "getKitsCmd", "showKits", true, true),
+
+        CMD_KITS_EDIT_HELP("kitedit", 1, "randomevent.kits.edit", "getKitsEditCmd", "showKitsEditHelp", true, true),
+
+        CMD_KITS_EDIT("kitedit", 2, "randomevent.kits.edit", "getKitsEditCmd", "editKit", true, true),
 
 	CMD_NEXT("next", 1, "randomevent.next", "getNext", "nextRandomEvents", true, true),
 	

--- a/RandomEvents/src/com/adri1711/randomevents/commands/ComandosExecutor.java
+++ b/RandomEvents/src/com/adri1711/randomevents/commands/ComandosExecutor.java
@@ -388,18 +388,23 @@ public class ComandosExecutor {
 
 	}
 
-	public void showKits(RandomEvents plugin, Player player) {
-		player.sendMessage(plugin.getLanguage().getTagPlugin() + "§e§lKits");
-		for (Kit m : plugin.getKits()) {
-			if (player != null) {
+        public void showKits(RandomEvents plugin, Player player) {
+                player.sendMessage(plugin.getLanguage().getTagPlugin() + "§e§lKits");
+                for (Kit m : plugin.getKits()) {
+                        if (player != null) {
 
-				player.sendMessage("§6§l" + plugin.getKits().indexOf(m) + " - " + m.getName());
-			} else {
-				plugin.getLoggerP().info(plugin.getKits().indexOf(m) + " - " + m.getName());
-			}
-		}
+                                player.sendMessage("§6§l" + plugin.getKits().indexOf(m) + " - " + m.getName());
+                        } else {
+                                plugin.getLoggerP().info(plugin.getKits().indexOf(m) + " - " + m.getName());
+                        }
+                }
 
-	}
+        }
+
+        public void showKitsEditHelp(RandomEvents plugin, Player player) {
+                showKits(plugin, player);
+                player.sendMessage(plugin.getLanguage().getKitsEditCmd());
+        }
 
 	public void nextRandomEvents(RandomEvents plugin, Player player) {
 		if (plugin.getSchedules() != null && !plugin.getSchedules().isEmpty()) {


### PR DESCRIPTION
## Summary
- provide a help handler when `/revent kitedit` is used without ID
- list kits and show usage message

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6848e236dda8833082642874882c340a