### PR TITLE
Fix GUI item pickup

### DIFF
--- a/RandomEvents/src/com/adri1711/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/adri1711/randomevents/listeners/GUI.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -37,7 +38,7 @@ public class GUI implements Listener {
 	}
 
 	@EventHandler
-	public void onInventoryClick(InventoryClickEvent event) {
+        public void onInventoryClick(InventoryClickEvent event) {
 
 		if (event.getWhoClicked() instanceof Player) {
 			try {
@@ -59,9 +60,10 @@ public class GUI implements Listener {
 								break;
 							default:
 								break;
-							}
-							
-						}
+                }
+
+        }
+
 					}
 				}
 			} catch (Throwable e) {
@@ -94,7 +96,23 @@ public class GUI implements Listener {
 		}
 	}
 
-	private void useCreditsGui(InventoryClickEvent event) {
+        @EventHandler
+        public void onInventoryDrag(InventoryDragEvent event) {
+                String invTitle = InventoryUtils.getInventoryTitle(event);
+                if (invTitle != null
+                                && (ChatColor.stripColor(invTitle)
+                                                .contains(ChatColor.stripColor(plugin.getLanguage().getStatsGuiName()))
+                                                || ChatColor.stripColor(invTitle)
+                                                                .contains(ChatColor.stripColor(plugin.getLanguage().getCreditsGuiName()))
+                                                || ChatColor.stripColor(invTitle)
+                                                                .contains(ChatColor.stripColor(plugin.getLanguage().getKitGuiName()))
+                                                || ChatColor.stripColor(invTitle)
+                                                                .contains(ChatColor.stripColor(plugin.getLanguage().getTeamGuiName())))) {
+                        event.setCancelled(true);
+                }
+        }
+
+        private void useCreditsGui(InventoryClickEvent event) {
 
                 if (event.getWhoClicked() instanceof Player) {
                         if (clickedTopInventory(event)) {
@@ -411,8 +429,15 @@ public class GUI implements Listener {
          * while still allowing normal interaction with their own inventory.
          */
         private boolean clickedTopInventory(InventoryClickEvent event) {
-                return event != null && event.getView() != null && event.getClickedInventory() != null
-                                && event.getView().getTopInventory().equals(event.getClickedInventory());
+                if (event == null || event.getView() == null) {
+                        return false;
+                }
+                if (event.getClickedInventory() != null && event.getView().getTopInventory() != null
+                                && event.getView().getTopInventory().equals(event.getClickedInventory())) {
+                        return true;
+                }
+                // Fallback using raw slot index for implementations that create new inventory instances
+                return event.getRawSlot() < event.getView().getTopInventory().getSize();
         }
 
         public RandomEvents getPlugin() {

--- a/RandomEvents/src/com/adri1711/randomevents/util/InventoryUtils.java
+++ b/RandomEvents/src/com/adri1711/randomevents/util/InventoryUtils.java
@@ -3,6 +3,7 @@ package com.adri1711.randomevents.util;
 import java.lang.reflect.Method;
 
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 
 public class InventoryUtils {
 
@@ -42,6 +43,65 @@ public class InventoryUtils {
         } catch (Exception ignore) {
         }
         // Fallback to Inventory#getTitle() or getName()
+        try {
+            Method getInventory = event.getClass().getMethod("getInventory");
+            Object inventory = getInventory.invoke(event);
+            try {
+                Method getTitle = inventory.getClass().getMethod("getTitle");
+                Object result = getTitle.invoke(inventory);
+                if (result != null) {
+                    return result.toString();
+                }
+            } catch (NoSuchMethodException ignored) {
+                try {
+                    Method getName = inventory.getClass().getMethod("getName");
+                    Object result = getName.invoke(inventory);
+                    if (result != null) {
+                        return result.toString();
+                    }
+                } catch (NoSuchMethodException ex) {
+                    // ignore
+                }
+            }
+        } catch (Exception ignore) {
+        }
+        return null;
+    }
+
+    /**
+     * Obtain the title of an inventory from an InventoryDragEvent using
+     * reflection to remain compatible across Minecraft versions.
+     *
+     * @param event InventoryDragEvent
+     * @return title of the inventory or null if not available
+     */
+    public static String getInventoryTitle(InventoryDragEvent event) {
+        if (event == null) {
+            return null;
+        }
+        try {
+            Method viewMethod = event.getClass().getMethod("getView");
+            Object view = viewMethod.invoke(event);
+            try {
+                Method getTitle = view.getClass().getMethod("getTitle");
+                Object result = getTitle.invoke(view);
+                if (result != null) {
+                    return result.toString();
+                }
+            } catch (NoSuchMethodException ignored) {
+                try {
+                    Method title = view.getClass().getMethod("title");
+                    Object result = title.invoke(view);
+                    if (result != null) {
+                        return result.toString();
+                    }
+                } catch (NoSuchMethodException ex) {
+                    // ignore
+                }
+            }
+        } catch (Exception ignore) {
+        }
+
         try {
             Method getInventory = event.getClass().getMethod("getInventory");
             Object inventory = getInventory.invoke(event);


### PR DESCRIPTION
## Summary
- prevent dragging items from plugin GUIs
- make clickedTopInventory more robust
- support fetching titles for InventoryDragEvent

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68495e6390ec8330a6b3c74d17b077e6