### PR TITLE
Fix GUI item grabbing

### DIFF
--- a/RandomEvents/src/com/adri1711/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/adri1711/randomevents/listeners/GUI.java
@@ -10,6 +10,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryType;
@@ -37,8 +38,8 @@ public class GUI implements Listener {
 		this.plugin = plugin;
 	}
 
-	@EventHandler
-        public void onInventoryClick(InventoryClickEvent event) {
+       @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+       public void onInventoryClick(InventoryClickEvent event) {
 
 		if (event.getWhoClicked() instanceof Player) {
 			try {
@@ -96,8 +97,8 @@ public class GUI implements Listener {
 		}
 	}
 
-        @EventHandler
-        public void onInventoryDrag(InventoryDragEvent event) {
+       @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+       public void onInventoryDrag(InventoryDragEvent event) {
                 String invTitle = InventoryUtils.getInventoryTitle(event);
                 if (invTitle != null
                                 && (ChatColor.stripColor(invTitle)


### PR DESCRIPTION
## Summary
- keep GUI items in place by ensuring we cancel drag and click events at the highest priority

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6849604873a48330ad56995d491740b8