### PR TITLE
Add missing Turkish translation

### DIFF
--- a/RandomEvents/messages_tr.yml
+++ b/RandomEvents/messages_tr.yml
@@ -142,6 +142,7 @@ menu.admin.forcebegin: "   &6/revent forcebegin:\n          &e-> Maça başlamak
 menu.admin.force: "   &6/revent begin:\n          &e-> Rastgele bir etkinliğe başlar"
 menu.admin.tforce: "   &6/revent tbegin:\n          &e-> Turnuva rastgele bir etkinliğe başlar"
 menu.admin.forceSpecific: "   &6/revent begin <sayi>:\n          &e-> Belirli bir rastgele olaya başlar"
+menu.guicmd: "   &6/revent gui:\n          &e-> Etkinlikleri gösteren menüyü açar"
 menu.admin.givecreditsrandom: "   &6/revent givecredits <oyuncu> <miktar>:\n          &e-> Rastgele seçilmiş bir etkinliğin kredisini ver"
 menu.admin.givecreditsspecific: "   &6/revent givecredits <etkinlikAdi> <oyuncu> <miktar>:\n          &e-> Belirli bir etkinliğin kredisini bir oyuncuya ver"
 menu.admin.balcreditsown: "   &6/revent credits:\n          &e-> Kredilerinizi gösterir"


### PR DESCRIPTION
## Summary
- fill missing translation for `menu.guicmd` command help

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_684a3a155cf083309beb194bfb2acce4