### PR TITLE
Enable language file translation for creation steps

### DIFF
--- a/RandomEvents/messages_tr.yml
+++ b/RandomEvents/messages_tr.yml
@@ -335,3 +335,7 @@ minigame.description.BLOCKPARTY: Bloklar kaybolduğunda düşmemeye çalışın;
   renklerle arayın ve hayatta kalın; Kazanana kadar!
 minigame.description.HIDEANDSEEK: Arayanlardan saklanın ya da belki de; Maçınızı kazanmak
   için!
+creation.minigame_type.name: Minigame Türü
+creation.minigame_type.message: "&6&lMinigame türünü seçin (Sohbete 0 yazın)"
+creation.battle_name.name: Etkinlik Adı
+creation.battle_name.message: "&6&lRandomEvent oluşturmayı başlattınız. Maçın adını yazın"

--- a/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
@@ -25,8 +25,40 @@ import net.md_5.bungee.api.ChatColor;
 public class LanguageMessages {
 	private File file;
 	private FileConfiguration fileConfig;
-	private RandomEvents plugin;
-	private Pattern pattern = Pattern.compile("&#[a-fA-F0-9]{6}");
+    private RandomEvents plugin;
+    private Pattern pattern = Pattern.compile("&#[a-fA-F0-9]{6}");
+
+    private String colorize(String s) {
+        if (s == null) {
+            return null;
+        }
+        try {
+            Matcher match = pattern.matcher(s);
+            Map<String, ChatColor> mapa = new HashMap<String, ChatColor>();
+            while (match.find()) {
+                String color = s.substring(match.start() + 1, match.end());
+                Method method = ChatColor.class.getMethod("of", String.class);
+                ChatColor chatc = (ChatColor) method.invoke(null, color);
+                mapa.put("&" + color, chatc);
+            }
+            for (Entry<String, ChatColor> ent : mapa.entrySet()) {
+                s = s.replaceAll(ent.getKey(), ent.getValue() + "");
+            }
+            s = ChatColor.translateAlternateColorCodes('&', s);
+        } catch (Exception e) {
+            s = s.replaceAll("&", "§");
+        }
+        s = s.replaceAll("\\n", Constantes.SALTO_LINEA);
+        return s;
+    }
+
+    public String getTranslation(String path) {
+        String s = fileConfig.getString(path);
+        if (s == null) {
+            return null;
+        }
+        return colorize(s);
+    }
 
 	private String tagChat;
 	private String invalidInput;

--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -342,7 +342,7 @@ public class Chat implements Listener {
 			plugin.getPlayerKit().remove(player.getName());
 			plugin.getPlayersCreationKit().remove(player.getName());
 			if (plugin.getPlayerMatches().containsKey(player.getName())) {
-				player.sendMessage(Creacion.KITS.getMessage());
+                                player.sendMessage(Creacion.KITS.getMessage(plugin));
 				for (Kit m : plugin.getKits()) {
 					player.sendMessage("§6§l" + plugin.getKits().indexOf(m) + " - " + m.getName());
 				}
@@ -553,7 +553,7 @@ public class Chat implements Listener {
 		} else {
 			plugin.getPlayerWaterDrop().remove(player.getName());
 			plugin.getPlayersCreationWaterDrop().remove(player.getName());
-			player.sendMessage(Creacion.WATER_DROP_SCENES.getMessage());
+                        player.sendMessage(Creacion.WATER_DROP_SCENES.getMessage(plugin));
 			for (WaterDropStep m : plugin.getWaterDrops()) {
 				player.sendMessage("§6§l" + plugin.getWaterDrops().indexOf(m) + " - " + m.getName());
 			}
@@ -1295,13 +1295,13 @@ public class Chat implements Listener {
 
 							} catch (Exception e) {
 								player.sendMessage(plugin.getLanguage().getInvalidInput());
-								player.sendMessage(c.getMessage(match));
+								player.sendMessage(c.getMessage(plugin, match));
 								actua = Boolean.FALSE;
 
 							}
 						} else {
 							if (plugin.getPlayerMatches().keySet().contains(player.getName())) {
-								player.sendMessage(c.getMessage(match));
+								player.sendMessage(c.getMessage(plugin, match));
 								plugin.getPlayersCreation().put(player.getName(), c.getPosition());
 								actua = Boolean.FALSE;
 							} else {
@@ -1478,7 +1478,7 @@ public class Chat implements Listener {
 
 						} catch (Exception e) {
 							player.sendMessage(plugin.getLanguage().getInvalidInput());
-							player.sendMessage(c.getMessage(match));
+							player.sendMessage(c.getMessage(plugin, match));
 							actua = Boolean.FALSE;
 
 						}
@@ -1502,7 +1502,7 @@ public class Chat implements Listener {
 						}
 						break;
 					case WATER_DROP_SCENES:
-						player.sendMessage(c.getMessage(match));
+						player.sendMessage(c.getMessage(plugin, match));
 						for (WaterDropStep m : plugin.getWaterDrops()) {
 							player.sendMessage("§6§l" + plugin.getWaterDrops().indexOf(m) + " - " + m.getName());
 						}
@@ -1510,7 +1510,7 @@ public class Chat implements Listener {
 
 						break;
 					case KITS:
-						player.sendMessage(c.getMessage(match));
+						player.sendMessage(c.getMessage(plugin, match));
 						for (Kit m : plugin.getKits()) {
 							player.sendMessage("§6§l" + plugin.getKits().indexOf(m) + " - " + m.getName());
 						}
@@ -1518,7 +1518,7 @@ public class Chat implements Listener {
 
 						break;
 					default:
-						player.sendMessage(c.getMessage(match));
+						player.sendMessage(c.getMessage(plugin, match));
 						break;
 					}
 					actua = Boolean.FALSE;
@@ -1537,7 +1537,7 @@ public class Chat implements Listener {
 					break;
 				case BATTLE_NAME:
 					if (!plugin.getEditando().contains(player.getName())) {
-						player.sendMessage(c.getMessage(match));
+						player.sendMessage(c.getMessage(plugin, match));
 						plugin.getPlayersCreation().put(player.getName(), c.getPosition());
 					}
 					break;
@@ -1549,7 +1549,7 @@ public class Chat implements Listener {
 
 					break;
 				case WATER_DROP_SCENES:
-					player.sendMessage(c.getMessage(match));
+					player.sendMessage(c.getMessage(plugin, match));
 					plugin.getPlayersCreation().put(player.getName(), c.getPosition());
 					for (WaterDropStep m : plugin.getWaterDrops()) {
 						player.sendMessage("§6§l" + plugin.getWaterDrops().indexOf(m) + " - " + m.getName());
@@ -1558,7 +1558,7 @@ public class Chat implements Listener {
 
 					break;
 				case KITS:
-					player.sendMessage(c.getMessage(match));
+					player.sendMessage(c.getMessage(plugin, match));
 					plugin.getPlayersCreation().put(player.getName(), c.getPosition());
 
 					for (Kit m : plugin.getKits()) {
@@ -1577,7 +1577,7 @@ public class Chat implements Listener {
 					break;
 
 				default:
-					player.sendMessage(c.getMessage(match));
+					player.sendMessage(c.getMessage(plugin, match));
 					plugin.getPlayersCreation().put(player.getName(), c.getPosition());
 
 					break;
@@ -1595,7 +1595,7 @@ public class Chat implements Listener {
 			} else {
 				c = Creacion.getByPosition(plugin.getPlayersCreation().get(player.getName()));
 				if (c != null && !pasado) {
-					player.sendMessage(c.getMessage(match));
+					player.sendMessage(c.getMessage(plugin, match));
 				}
 			}
 		} else {

--- a/RandomEvents/src/com/immortalman01/randomevents/match/enums/Creacion.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/enums/Creacion.java
@@ -218,9 +218,15 @@ public enum Creacion {
 		return position;
 	}
 
-	public String getName() {
-		return name;
-	}
+        public String getName(com.immortalman01.randomevents.RandomEvents plugin) {
+                String key = "creation." + this.name().toLowerCase() + ".name";
+                String res = plugin.getLanguage().getTranslation(key);
+                return res != null ? res : name;
+        }
+
+        public String getName() {
+                return name;
+        }
 
 	public void setName(String name) {
 		this.name = name;
@@ -230,20 +236,27 @@ public enum Creacion {
 		this.position = position;
 	}
 
-	public String getMessage() {
-		return message;
-	}
+        public String getMessage(com.immortalman01.randomevents.RandomEvents plugin) {
+                String key = "creation." + this.name().toLowerCase() + ".message";
+                String res = plugin.getLanguage().getTranslation(key);
+                return res != null ? res : message;
+        }
 
-	public String getMessage(Match m) {
-		if (m == null || m.getAmountPlayers() == null) {
-			return message;
-		} else {
-			return message.replaceAll("%entities%", "" + m.getEntitySpawns().size())
-					.replaceAll("%players%", "" + m.getSpawns().size())
-					.replaceAll("%maxPlayers%", "" + m.getAmountPlayers())
-					.replaceAll("%maxTeams%", "" + m.getNumberOfTeams());
-		}
-	}
+        public String getMessage() {
+                return message;
+        }
+
+        public String getMessage(com.immortalman01.randomevents.RandomEvents plugin, Match m) {
+                String base = getMessage(plugin);
+                if (m == null || m.getAmountPlayers() == null) {
+                        return base;
+                } else {
+                        return base.replaceAll("%entities%", "" + m.getEntitySpawns().size())
+                                        .replaceAll("%players%", "" + m.getSpawns().size())
+                                        .replaceAll("%maxPlayers%", "" + m.getAmountPlayers())
+                                        .replaceAll("%maxTeams%", "" + m.getNumberOfTeams());
+                }
+        }
 
 	public static List<Creacion> getCreaciones(Match m) {
 		List<Creacion> creaciones = new ArrayList<Creacion>();

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -2050,15 +2050,15 @@ public class UtilsRandomEvents {
 	public static String enviaInfoCreacion(Match match, Player player, RandomEvents plugin) {
 		String info = plugin.getLanguage().getTagPlugin() + " ";
 		if (match.getMinigame() == null) {
-			info += Constantes.SALTO_LINEA + "§e§l " + Creacion.MINIGAME_TYPE.ordinal() + " - "
-					+ Creacion.MINIGAME_TYPE.getMessage();
+                        info += Constantes.SALTO_LINEA + "§e§l " + Creacion.MINIGAME_TYPE.ordinal() + " - "
+                                        + Creacion.MINIGAME_TYPE.getMessage(plugin);
 
 		} else {
 
 			for (Creacion c : Creacion.getCreaciones(match)) {
 				if (!match.getMinigame().equals(MinigameType.WDROP)
 						|| (match.getMinigame().equals(MinigameType.WDROP) && !c.equals(Creacion.ARENA_SPAWNS))) {
-					info += Constantes.SALTO_LINEA + "§e§l " + c.getPosition() + " - " + c.getName();
+                                        info += Constantes.SALTO_LINEA + "§e§l " + c.getPosition() + " - " + c.getName(plugin);
 
 					switch (c) {
 


### PR DESCRIPTION
## Summary
- add `getTranslation` utility to `LanguageMessages`
- allow `Creacion` enum to read translated step names and messages
- show translated text during match creation
- update chat handling to use new API
- provide Turkish translations for the first steps

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684a9c80f3c48330bbf32718b4b4d67f