### PR TITLE
Use custom InventoryHolder for menus

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -27,6 +27,7 @@ import com.immortalman01.randomevents.util.Constantes;
 import com.immortalman01.randomevents.util.InventoryUtils;
 import com.immortalman01.randomevents.util.UtilsRandomEvents;
 import com.immortalman01.randomevents.util.UtilsSQL;
+import com.immortalman01.randomevents.util.RandomEventsHolder;
 import com.immortalman01.util.enums.XMaterial;
 import com.immortalman01.util.enums.XSound;
 
@@ -72,45 +73,42 @@ public class GUI implements Listener {
 			}
 		}
 
-                String invTitle = InventoryUtils.getInventoryTitle(event);
+               Inventory topInventory = event.getView().getTopInventory();
+               boolean pluginMenu = topInventory != null && topInventory.getHolder() instanceof RandomEventsHolder;
 
-                if (invTitle != null
-                                && ChatColor.stripColor(invTitle)
-                                                .contains(ChatColor.stripColor(plugin.getLanguage().getStatsGuiName()))) {
-                        if (clickedTopInventory(event)) {
-                                event.setCancelled(true);
-                        }
-                } else if (invTitle != null
-                                && ChatColor.stripColor(invTitle)
-                                                .contains(ChatColor.stripColor(plugin.getLanguage().getCreditsGuiName()))) {
-                        useCreditsGui(event);
-                } else if (invTitle != null
-                                && ChatColor.stripColor(invTitle)
-                                                .contains(ChatColor.stripColor(plugin.getLanguage().getKitGuiName()))) {
-                        useKitGUI(event);
+               if (pluginMenu) {
+                       String invTitle = InventoryUtils.getInventoryTitle(event);
 
-                } else if (invTitle != null
-                                && ChatColor.stripColor(invTitle)
-                                                .contains(ChatColor.stripColor(plugin.getLanguage().getTeamGuiName()))) {
-                        useTeamGUI(event);
+                       if (invTitle != null
+                                       && ChatColor.stripColor(invTitle)
+                                                       .contains(ChatColor.stripColor(plugin.getLanguage().getStatsGuiName()))) {
+                               if (clickedTopInventory(event)) {
+                                       event.setCancelled(true);
+                               }
+                       } else if (invTitle != null
+                                       && ChatColor.stripColor(invTitle)
+                                                       .contains(ChatColor.stripColor(plugin.getLanguage().getCreditsGuiName()))) {
+                               useCreditsGui(event);
+                       } else if (invTitle != null
+                                       && ChatColor.stripColor(invTitle)
+                                                       .contains(ChatColor.stripColor(plugin.getLanguage().getKitGuiName()))) {
+                               useKitGUI(event);
 
-		}
-	}
+                       } else if (invTitle != null
+                                       && ChatColor.stripColor(invTitle)
+                                                       .contains(ChatColor.stripColor(plugin.getLanguage().getTeamGuiName()))) {
+                               useTeamGUI(event);
+
+                       }
+               }
+       }
 
        @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
        public void onInventoryDrag(InventoryDragEvent event) {
-                String invTitle = InventoryUtils.getInventoryTitle(event);
-                if (invTitle != null
-                                && (ChatColor.stripColor(invTitle)
-                                                .contains(ChatColor.stripColor(plugin.getLanguage().getStatsGuiName()))
-                                                || ChatColor.stripColor(invTitle)
-                                                                .contains(ChatColor.stripColor(plugin.getLanguage().getCreditsGuiName()))
-                                                || ChatColor.stripColor(invTitle)
-                                                                .contains(ChatColor.stripColor(plugin.getLanguage().getKitGuiName()))
-                                                || ChatColor.stripColor(invTitle)
-                                                                .contains(ChatColor.stripColor(plugin.getLanguage().getTeamGuiName())))) {
-                        event.setCancelled(true);
-                }
+               Inventory topInventory = event.getView().getTopInventory();
+               if (topInventory != null && topInventory.getHolder() instanceof RandomEventsHolder) {
+                       event.setCancelled(true);
+               }
         }
 
         private void useCreditsGui(InventoryClickEvent event) {

--- a/RandomEvents/src/com/immortalman01/randomevents/util/RandomEventsHolder.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/RandomEventsHolder.java
@@ -1,0 +1,15 @@
+package com.immortalman01.randomevents.util;
+
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+/**
+ * Marker holder used for RandomEvents GUIs so we can reliably detect
+ * plugin inventories regardless of title conversion across versions.
+ */
+public class RandomEventsHolder implements InventoryHolder {
+    @Override
+    public Inventory getInventory() {
+        return null;
+    }
+}

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -74,6 +74,7 @@ import com.immortalman01.randomevents.match.utils.BannedPlayers;
 import com.immortalman01.randomevents.match.utils.Cuboid;
 import com.immortalman01.randomevents.match.utils.InventoryPers;
 import com.immortalman01.randomevents.stats.Stats;
+import com.immortalman01.randomevents.util.RandomEventsHolder;
 import com.immortalman01.util.enums.Particle1711;
 import com.immortalman01.util.enums.ParticleDisplay;
 import com.immortalman01.util.enums.XMaterial;
@@ -1615,8 +1616,9 @@ public class UtilsRandomEvents {
 	}
 
 	public static Inventory createGUI(String name, Stats estadisticas, RandomEvents plugin) {
-		Inventory inv = Bukkit.createInventory(null, plugin.getReventConfig().getStatsSize(),
-				plugin.getLanguage().getStatsGuiName() + name);
+               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(),
+                               plugin.getReventConfig().getStatsSize(),
+                               plugin.getLanguage().getStatsGuiName() + name);
 		for (MinigameType minigame : MinigameType.values()) {
 			Integer position = -1;
 			try {
@@ -3283,7 +3285,8 @@ public class UtilsRandomEvents {
 
 	public static Inventory createGUICredits(Player p, Map<String, Integer> creditos, Integer page,
 			RandomEvents plugin) {
-		Inventory inv = Bukkit.createInventory(null, 45, plugin.getLanguage().getCreditsGuiName());
+               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(), 45,
+                               plugin.getLanguage().getCreditsGuiName());
 		ItemStack nextPage = new ItemStack(XMaterial.OAK_SIGN.parseMaterial());
 		ItemStack backPage = new ItemStack(XMaterial.OAK_SIGN.parseMaterial());
 		ItemMeta nextPageMeta = nextPage.getItemMeta();
@@ -3385,14 +3388,16 @@ public class UtilsRandomEvents {
 
 	public static Inventory createGUIKits(Player p, Integer page, RandomEvents plugin, MatchActive matchActive) {
 
-		Inventory inv = Bukkit.createInventory(null, 45, plugin.getLanguage().getKitGuiName());
+               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(), 45,
+                               plugin.getLanguage().getKitGuiName());
 
 		if (matchActive != null) {
 			Match match = matchActive.getMatch();
 			List<Kit> kitsAvailable = UtilsRandomEvents.kitsAvailable(p, match.getKits(), plugin);
 
 			Integer size = UtilsRandomEvents.sizeGUIKits(kitsAvailable);
-			inv = Bukkit.createInventory(null, size, plugin.getLanguage().getKitGuiName());
+                       inv = Bukkit.createInventory(new RandomEventsHolder(), size,
+                                       plugin.getLanguage().getKitGuiName());
 			ItemStack nextPage = new ItemStack(XMaterial.OAK_SIGN.parseMaterial());
 			ItemStack backPage = new ItemStack(XMaterial.OAK_SIGN.parseMaterial());
 			ItemMeta nextPageMeta = nextPage.getItemMeta();
@@ -3438,7 +3443,8 @@ public class UtilsRandomEvents {
 
 	public static Inventory createGUITeams(Player p, Integer page, RandomEvents plugin, MatchActive matchActive) {
 
-		Inventory inv = Bukkit.createInventory(null, 9, plugin.getLanguage().getTeamGuiName());
+               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(), 9,
+                               plugin.getLanguage().getTeamGuiName());
 
 		if (matchActive != null) {
 			Match match = matchActive.getMatch();


### PR DESCRIPTION
## Summary
- add `RandomEventsHolder` to mark plugin inventories
- create menus with the new holder
- detect plugin GUIs using the holder in `GUI` events

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684acdeb319c8330bcf1ce78f3c511cd