### PR TITLE
Fix encoding in Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,8 @@ subprojects {
     targetCompatibility = JavaVersion.VERSION_21
 
     tasks.withType(JavaCompile).configureEach {
-        options.encoding = 'windows-1252'
+        // Use UTF-8 so source files with special characters compile correctly
+        options.encoding = 'UTF-8'
     }
 
     repositories {


### PR DESCRIPTION
## Summary
- compile source files using UTF-8 so colored characters display correctly

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_684b4c85a5e48330bc4ba1f11cf1afc2