### PR TITLE
Fix kit creation text localization

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -218,13 +218,13 @@ public class Chat implements Listener {
 
 							} catch (Exception e) {
 								player.sendMessage(plugin.getLanguage().getInvalidInput());
-								player.sendMessage(c.getMessage());
+								player.sendMessage(c.getMessage(plugin));
 								actua = Boolean.FALSE;
 
 							}
 						} else {
 							if (plugin.getPlayerKit().keySet().contains(player.getName())) {
-								player.sendMessage(c.getMessage());
+								player.sendMessage(c.getMessage(plugin));
 								plugin.getPlayersCreationKit().put(player.getName(), c.getPosition());
 								actua = Boolean.FALSE;
 							} else {
@@ -294,7 +294,7 @@ public class Chat implements Listener {
 
 						} catch (Exception e) {
 							player.sendMessage(plugin.getLanguage().getInvalidInput());
-							player.sendMessage(c.getMessage());
+							player.sendMessage(c.getMessage(plugin));
 							actua = Boolean.FALSE;
 
 						}
@@ -308,7 +308,7 @@ public class Chat implements Listener {
 					switch (CreacionKit.getByPosition(position)) {
 
 					default:
-						player.sendMessage(c.getMessage());
+						player.sendMessage(c.getMessage(plugin));
 						break;
 					}
 					actua = Boolean.FALSE;
@@ -335,7 +335,7 @@ public class Chat implements Listener {
 			} else {
 				c = CreacionKit.getByPosition(plugin.getPlayersCreationKit().get(player.getName()));
 				if (c != null && !pasado) {
-					player.sendMessage(c.getMessage());
+					player.sendMessage(c.getMessage(plugin));
 				}
 			}
 		} else {
@@ -430,13 +430,13 @@ public class Chat implements Listener {
 
 							} catch (Exception e) {
 								player.sendMessage(plugin.getLanguage().getInvalidInput());
-								player.sendMessage(c.getMessage());
+								player.sendMessage(c.getMessage(plugin));
 								actua = Boolean.FALSE;
 
 							}
 						} else {
 							if (plugin.getPlayerWaterDrop().keySet().contains(player.getName())) {
-								player.sendMessage(c.getMessage());
+								player.sendMessage(c.getMessage(plugin));
 								plugin.getPlayersCreationWaterDrop().put(player.getName(), c.getPosition());
 								actua = Boolean.FALSE;
 							} else {
@@ -506,7 +506,7 @@ public class Chat implements Listener {
 
 						} catch (Exception e) {
 							player.sendMessage(plugin.getLanguage().getInvalidInput());
-							player.sendMessage(c.getMessage());
+							player.sendMessage(c.getMessage(plugin));
 							actua = Boolean.FALSE;
 
 						}
@@ -520,7 +520,7 @@ public class Chat implements Listener {
 					switch (CreacionWaterDrop.getByPosition(position)) {
 
 					default:
-						player.sendMessage(c.getMessage());
+						player.sendMessage(c.getMessage(plugin));
 						break;
 					}
 					actua = Boolean.FALSE;
@@ -547,7 +547,7 @@ public class Chat implements Listener {
 			} else {
 				c = CreacionWaterDrop.getByPosition(plugin.getPlayersCreationWaterDrop().get(player.getName()));
 				if (c != null && !pasado) {
-					player.sendMessage(c.getMessage());
+					player.sendMessage(c.getMessage(plugin));
 				}
 			}
 		} else {

--- a/RandomEvents/src/com/immortalman01/randomevents/match/enums/CreacionKit.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/enums/CreacionKit.java
@@ -2,22 +2,22 @@ package com.immortalman01.randomevents.match.enums;
 
 public enum CreacionKit {
 
-	NAME(0, "§6§lChoose Name"),
-	
-	ITEM_DESCRIPTIVE(1, "§6§Put the item on your hand and say 'Done' (It can have custom name or lore, if not it will take the default name and lore from messages.yml)"),
+        NAME(0, "§6§lChoose Name"),
 
-	PERMISSION_OPTIONAL(2, "§6§lWrite the permission needed to use this kit"),
+        ITEM_DESCRIPTIVE(1, "§6§Put the item on your hand and say 'Done' (It can have custom name or lore, if not it will take the default name and lore from messages.yml)"),
 
-	INVENTORY(3, "§6§lTake the inventory for the players and say 'Done' "),
+        PERMISSION_OPTIONAL(2, "§6§lWrite the permission needed to use this kit"),
 
-	SAVE(997, "§6§lYou are about to save a Kit, put 'Y' to confirm or 'N' to continue creating"),
+        INVENTORY(3, "§6§lTake the inventory for the players and say 'Done' "),
 
-	DELETE(998, "§6§lChoose the field you want to remove"),
+        SAVE(997, "§6§lYou are about to save a Kit, put 'Y' to confirm or 'N' to continue creating"),
 
-	CANCEL(999, "§6§lYou are about to cancel a Kit, put 'Y' to confirm or 'N' to continue creating");
+        DELETE(998, "§6§lChoose the field you want to remove"),
 
-	private Integer position;
-	private String message;
+        CANCEL(999, "§6§lYou are about to cancel a Kit, put 'Y' to confirm or 'N' to continue creating");
+
+        private Integer position;
+        private String message;
 
 
 	private CreacionKit(Integer position, String message) {
@@ -46,9 +46,15 @@ public enum CreacionKit {
 		this.position = position;
 	}
 
-	public String getMessage() {
-		return message;
-	}
+        public String getMessage() {
+                return message;
+        }
+
+        public String getMessage(com.immortalman01.randomevents.RandomEvents plugin) {
+                String key = "creation.kit_" + this.name().toLowerCase() + ".message";
+                String res = plugin.getLanguage().getTranslation(key);
+                return res != null ? res : message;
+        }
 
 
 

--- a/RandomEvents/src/com/immortalman01/randomevents/match/enums/CreacionWaterDrop.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/enums/CreacionWaterDrop.java
@@ -16,8 +16,8 @@ public enum CreacionWaterDrop {
 
 	CANCEL(999, "§6§lYou are about to cancel a Water drop, put 'Y' to confirm or 'N' to continue creating");
 
-	private Integer position;
-	private String message;
+        private Integer position;
+        private String message;
 
 
 	private CreacionWaterDrop(Integer position, String message) {
@@ -46,9 +46,15 @@ public enum CreacionWaterDrop {
 		this.position = position;
 	}
 
-	public String getMessage() {
-		return message;
-	}
+        public String getMessage() {
+                return message;
+        }
+
+        public String getMessage(com.immortalman01.randomevents.RandomEvents plugin) {
+                String key = "creation." + this.name().toLowerCase() + ".message";
+                String res = plugin.getLanguage().getTranslation(key);
+                return res != null ? res : message;
+        }
 
 
 

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -3097,8 +3097,12 @@ public class UtilsRandomEvents {
 	public static String enviaInfoCreacionKit(Kit kit, Player player, RandomEvents plugin) {
 		String info = plugin.getLanguage().getTagPlugin() + " ";
 
-		for (CreacionKit c : CreacionKit.values()) {
-			info += Constantes.SALTO_LINEA + "§e§l " + c.getPosition() + " - " + c.toString();
+                for (CreacionKit c : CreacionKit.values()) {
+                        String name = plugin.getLanguage()
+                                        .getTranslation("creation.kit_" + c.name().toLowerCase() + ".name");
+                        if (name == null)
+                                name = c.toString();
+                        info += Constantes.SALTO_LINEA + "§e§l " + c.getPosition() + " - " + name;
 
 			switch (c) {
 


### PR DESCRIPTION
## Summary
- use localization keys for kit creation prompts
- show translated step names in kit info listing
- hook water drop steps into language translations

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_684b5b333f908330a881a30973742d0d