### PR TITLE
Fix probability parsing for rewards

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -1247,8 +1247,8 @@ public class MatchActive {
 					Boolean ejecutaComando = Boolean.TRUE;
 					String[] trozosComandos = comando.split(" ");
 
-					if (trozosComandos[0].trim().equals(Constantes.PROBABILITY_CMD)) {
-						Integer probabilidad = Integer.valueOf(trozosComandos[1]);
+                                        if (trozosComandos[0].trim().equals(Constantes.PROBABILITY_CMD)) {
+                                                Integer probabilidad = UtilsRandomEvents.parseProbability(trozosComandos[1]);
 						Integer aleatorio = random.nextInt(100);
 
 						if (aleatorio > probabilidad) {

--- a/RandomEvents/src/com/immortalman01/randomevents/match/TournamentActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/TournamentActive.java
@@ -414,8 +414,8 @@ public class TournamentActive {
 				Boolean ejecutaComando = Boolean.TRUE;
 				String[] trozosComandos = comando.split(" ");
 
-				if (trozosComandos[0].trim().equals(Constantes.PROBABILITY_CMD)) {
-					Integer probabilidad = Integer.valueOf(trozosComandos[1]);
+if (trozosComandos[0].trim().equals(Constantes.PROBABILITY_CMD)) {
+Integer probabilidad = UtilsRandomEvents.parseProbability(trozosComandos[1]);
 					Integer aleatorio = plugin.getRandom().nextInt(100);
 
 					if (aleatorio > probabilidad) {

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -3599,7 +3599,7 @@ public class UtilsRandomEvents {
 		return res;
 	}
 
-	public static Integer getTeamMorePlayers(RandomEvents plugin, Map<Integer, Set<Player>> teams) {
+public static Integer getTeamMorePlayers(RandomEvents plugin, Map<Integer, Set<Player>> teams) {
 
 		Integer max = 0;
 		Integer res = 0;
@@ -3611,9 +3611,24 @@ public class UtilsRandomEvents {
 			}
 
 		}
-		return res;
+return res;
 
-	}
+}
+
+public static int parseProbability(String value) {
+if (value == null) {
+return 0;
+}
+String digits = value.replaceAll("[^0-9]", "");
+if (digits.isEmpty()) {
+return 0;
+}
+try {
+return Integer.parseInt(digits);
+} catch (NumberFormatException e) {
+return 0;
+}
+}
 
 	public static void doCommandsKill(Player p, RandomEvents plugin) {
 		for (String cmd : plugin.getReventConfig().getCommandsOnKill()) {
@@ -3621,8 +3636,8 @@ public class UtilsRandomEvents {
 			Boolean ejecutaComando = Boolean.TRUE;
 			String[] trozosComandos = cmd.split(" ");
 
-			if (trozosComandos[0].trim().equals(Constantes.PROBABILITY_CMD)) {
-				Integer probabilidad = Integer.valueOf(trozosComandos[1]);
+if (trozosComandos[0].trim().equals(Constantes.PROBABILITY_CMD)) {
+Integer probabilidad = parseProbability(trozosComandos[1]);
 				Integer aleatorio = plugin.getRandom().nextInt(100);
 
 				if (aleatorio > probabilidad) {


### PR DESCRIPTION
## Summary
- add `parseProbability` helper
- use helper to parse probability in reward commands

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_684b60e8f0848330bec4c9fb10c100c2