### PR TITLE
Fix TNT explosion effect for 1.21

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -3226,7 +3226,11 @@ public class MatchActive {
                                        try {
                                                loc.getWorld().playEffect(loc, Effect.valueOf("EXPLOSION_HUGE"), 0);
                                        } catch (Throwable ignore) {
-                                               loc.getWorld().playEffect(loc, Effect.EXPLOSION_LARGE, 0);
+                                               try {
+                                                       loc.getWorld().playEffect(loc, Effect.valueOf("EXPLOSION_LARGE"), 0);
+                                               } catch (Throwable ignore2) {
+                                                       loc.getWorld().createExplosion(loc.getX(), loc.getY(), loc.getZ(), 0F, false, false);
+                                               }
                                        }
                                }
                                loc.getWorld().playSound(loc, XSound.ENTITY_GENERIC_EXPLODE.parseSound(), 1.0F, 1.0F);


### PR DESCRIPTION
## Summary
- avoid using removed `Effect.EXPLOSION_LARGE`
- fall back to `createExplosion` when necessary

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_684b6d44f9d08330a3ec013abe3edab9