### PR TITLE
Fix missing English messages

### DIFF
--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -20,13 +20,13 @@ sourceSets {
         java.srcDir 'src'
         java.exclude 'com/immortalman01/randomevents/util/UtilsProtocolLib.java'
         resources.srcDir '.'
-        resources.includes = ['plugin.yml','config.yml','defaultConfig.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs']
+        resources.includes = ['plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs']
     }
 }
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from('.') {
-        include 'plugin.yml','config.yml','defaultConfig.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs'
+        include 'plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs'
     }
 }

--- a/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
@@ -507,8 +507,22 @@ public class LanguageMessages {
 	}
 
         private FileConfiguration setFileConfigDefault(FileConfiguration fileConfig) {
-                for (Constantes.Messages m : Constantes.Messages.values()) {
-                        fileConfig.set(m.getYmlField(), m.getMessageDefault());
+                try {
+                        java.io.InputStream is = plugin.getResource("messages.yml");
+                        if (is != null) {
+                                FileConfiguration enConfig = YamlConfiguration.loadConfiguration(new java.io.InputStreamReader(is, "UTF-8"));
+                                for (String key : enConfig.getKeys(false)) {
+                                        fileConfig.set(key, enConfig.get(key));
+                                }
+                        } else {
+                                for (Constantes.Messages m : Constantes.Messages.values()) {
+                                        fileConfig.set(m.getYmlField(), m.getMessageDefault());
+                                }
+                        }
+                } catch (Exception e) {
+                        for (Constantes.Messages m : Constantes.Messages.values()) {
+                                fileConfig.set(m.getYmlField(), m.getMessageDefault());
+                        }
                 }
                 return fileConfig;
         }


### PR DESCRIPTION
## Summary
- package English messages as a resource
- load default English messages from the resource file if available

## Testing
- `gradle assemble`

------
https://chatgpt.com/codex/tasks/task_e_684b7cea1d5c83309aa877fbe1b292f2