### PR TITLE
Fix arena spawn reset

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -611,12 +611,13 @@ public class Chat implements Listener {
                 if (position != null) {
                         try {
                                 int pos = Integer.parseInt(message);
-                                if ((position.equals(Creacion.ARENA_SPAWNS.getPosition())
-                                                || position.equals(Creacion.ANOTHER_ARENA_SPAWNS.getPosition()))
-                                                && Creacion.getByPosition(pos) != null) {
+                                if (Creacion.getByPosition(pos) != null) {
                                         plugin.getPlayersCreation().put(player.getName(), pos);
                                         c = Creacion.getByPosition(pos);
                                         actua = Boolean.FALSE;
+                                        if (c.equals(Creacion.ARENA_SPAWNS)) {
+                                                match.setSpawns(new ArrayList<Location>());
+                                        }
                                 } else {
                                         c = Creacion.getByPosition(position);
                                 }


### PR DESCRIPTION
## Summary
- allow selecting any creation step by entering its number
- reset the spawn list when returning to the `ARENA_SPAWNS` step

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_684c04597ee08330b254230398824eda