### PR TITLE
Fix setup step jump when entering max players

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -609,25 +609,37 @@ public class Chat implements Listener {
 
                 Creacion c = null;
                 if (position != null) {
+                        Creacion current = Creacion.getByPosition(position);
                         if (position.equals(Creacion.MINIGAME_TYPE.getPosition())) {
                                 // When selecting a minigame we don't want to interpret the input
                                 // as another creation step. Let the MINIGAME_TYPE case handle it.
                                 c = Creacion.MINIGAME_TYPE;
                         } else {
-                                try {
-                                        int pos = Integer.parseInt(message);
-                                        if (Creacion.getByPosition(pos) != null) {
-                                                plugin.getPlayersCreation().put(player.getName(), pos);
-                                                c = Creacion.getByPosition(pos);
-                                                actua = Boolean.FALSE;
-                                                if (c.equals(Creacion.ARENA_SPAWNS)) {
-                                                        match.setSpawns(new ArrayList<Location>());
+                                boolean parseStep = true;
+                                if (current != null && (current.equals(Creacion.AMOUNT_PLAYERS)
+                                                || current.equals(Creacion.AMOUNT_PLAYERS_MIN))) {
+                                        // These steps expect a numeric value. Don't interpret it as a step change.
+                                        parseStep = false;
+                                }
+
+                                if (parseStep) {
+                                        try {
+                                                int pos = Integer.parseInt(message);
+                                                if (Creacion.getByPosition(pos) != null) {
+                                                        plugin.getPlayersCreation().put(player.getName(), pos);
+                                                        c = Creacion.getByPosition(pos);
+                                                        actua = Boolean.FALSE;
+                                                        if (c.equals(Creacion.ARENA_SPAWNS)) {
+                                                                match.setSpawns(new ArrayList<Location>());
+                                                        }
+                                                } else {
+                                                        c = Creacion.getByPosition(position);
                                                 }
-                                        } else {
+                                        } catch (Exception ex) {
                                                 c = Creacion.getByPosition(position);
                                         }
-                                } catch (Exception ex) {
-                                        c = Creacion.getByPosition(position);
+                                } else {
+                                        c = current;
                                 }
                         }
                 } else {


### PR DESCRIPTION
## Summary
- prevent numeric player count inputs from switching creation steps

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68532d71bf70833092da24c0551589c4