### PR TITLE
Fix numeric value parsing during minigame creation

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -617,7 +617,10 @@ public class Chat implements Listener {
                                 boolean parseStep = true;
                                 if (current != null && (current.equals(Creacion.AMOUNT_PLAYERS)
                                                 || current.equals(Creacion.AMOUNT_PLAYERS_MIN)
-                                                || current.equals(Creacion.KITS))) {
+                                                || current.equals(Creacion.KITS)
+                                                || current.equals(Creacion.WARMUP_TIME)
+                                                || current.equals(Creacion.NO_MOVE_TIME)
+                                                || current.equals(Creacion.REFILL_CHEST))) {
                                         // These steps expect a numeric value. Don't interpret it as a step change.
                                         parseStep = false;
                                 }


### PR DESCRIPTION
## Summary
- handle numeric input for warmup, movement and chest refill times

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_685337805ca48330948870a5aa147814