### PR TITLE
Fix chest refill step not advancing correctly

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -1126,11 +1126,15 @@ public class Chat implements Listener {
 						plugin.getPlayersCreation().remove(player.getName());
 
 						break;
-					case REFILL_CHEST:
-						match.setTimeRefill(Integer.valueOf(message.trim()));
-						plugin.getPlayersCreation().remove(player.getName());
+                                        case REFILL_CHEST:
+                                                match.setTimeRefill(Integer.valueOf(message.trim()));
+                                                // Go directly to the next step so numeric values are not
+                                                // interpreted as a new menu option.
+                                                plugin.getPlayersCreation().put(player.getName(),
+                                                                Creacion.TIMER_BLOCK_DISAPPEAR.getPosition());
+                                                actua = Boolean.FALSE;
 
-						break;
+                                                break;
 					case TIMER_BLOCK_DISAPPEAR:
 						match.setBlockTimer(Integer.valueOf(message.trim()));
 						plugin.getPlayersCreation().remove(player.getName());


### PR DESCRIPTION
## Summary
- ensure entering chest refill time doesn't interpret the value as another menu option
- automatically prompt for block disappear time after setting the refill value

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_68533b414d6c8330a09b57016289c781