### PR TITLE
Fix duplicate map update in checkMessageCreation

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -1681,11 +1681,10 @@ public class Chat implements Listener {
 			}
 		}
 
-		if (actualiza)
+                if (actualiza)
 
-		{
-			plugin.getPlayerMatches().put(player.getName(), match);
-			plugin.getPlayerMatches().put(player.getName(), match);
+                {
+                        plugin.getPlayerMatches().put(player.getName(), match);
 			if (actua) {
 				player.sendMessage(UtilsRandomEvents.enviaInfoCreacion(match, player, plugin));
 			} else {


### PR DESCRIPTION
## Summary
- avoid calling `getPlayerMatches().put()` twice in `checkMessageCreation`

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6853807f4f988330b566686983a02b20