### PR TITLE
Remove duplicate waterDrop assignment

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -578,7 +578,6 @@ public class Chat implements Listener {
 
 		if (actualiza) {
 			plugin.getPlayerWaterDrop().put(player.getName(), waterDrop);
-			plugin.getPlayerWaterDrop().put(player.getName(), waterDrop);
 			if (actua) {
 				player.sendMessage(UtilsRandomEvents.enviaInfoCreacionWaterDrop(waterDrop, player, plugin));
 			} else {


### PR DESCRIPTION
## Summary
- cleanup duplicated `getPlayerWaterDrop` call in `Chat` listener

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68538a0c973083308d861f5052a60f56