### PR TITLE
Fix validation for player count steps

### DIFF
--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     compileOnly 'commons-lang:commons-lang:2.6'
     compileOnly project(':stubs')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'org.mockito:mockito-core:5.11.0'
+    testImplementation 'org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT'
 }
 
 sourceSets {

--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -696,18 +696,40 @@ public class Chat implements Listener {
 
 						break;
 
-					case AMOUNT_PLAYERS:
-						match.setAmountPlayers(Integer.valueOf(message.trim()));
-						match.setSpawns(new ArrayList<Location>());
+                                        case AMOUNT_PLAYERS:
+                                                try {
+                                                        int maxPlayers = Integer.parseInt(message.trim());
+                                                        if (maxPlayers > 0) {
+                                                                match.setAmountPlayers(maxPlayers);
+                                                                match.setSpawns(new ArrayList<Location>());
+                                                                plugin.getPlayersCreation().remove(player.getName());
+                                                        } else {
+                                                                player.sendMessage(plugin.getLanguage().getInvalidInput());
+                                                                actua = Boolean.FALSE;
+                                                        }
+                                                } catch (Exception e) {
+                                                        player.sendMessage(plugin.getLanguage().getInvalidInput());
+                                                        actua = Boolean.FALSE;
+                                                }
 
-						plugin.getPlayersCreation().remove(player.getName());
+                                                break;
+                                        case AMOUNT_PLAYERS_MIN:
+                                                try {
+                                                        int minPlayers = Integer.parseInt(message.trim());
+                                                        Integer max = match.getAmountPlayers();
+                                                        if (minPlayers > 0 && (max == null || minPlayers <= max)) {
+                                                                match.setAmountPlayersMin(minPlayers);
+                                                                plugin.getPlayersCreation().remove(player.getName());
+                                                        } else {
+                                                                player.sendMessage(plugin.getLanguage().getInvalidInput());
+                                                                actua = Boolean.FALSE;
+                                                        }
+                                                } catch (Exception e) {
+                                                        player.sendMessage(plugin.getLanguage().getInvalidInput());
+                                                        actua = Boolean.FALSE;
+                                                }
 
-						break;
-					case AMOUNT_PLAYERS_MIN:
-						match.setAmountPlayersMin(Integer.valueOf(message.trim()));
-						plugin.getPlayersCreation().remove(player.getName());
-
-						break;
+                                                break;
 					case NUMBER_OF_TEAMS:
 						Integer number = Integer.valueOf(message.trim());
 						if (number > 1 && number < 9) {

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatPlayerCountTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatPlayerCountTest.java
@@ -1,0 +1,99 @@
+package com.immortalman01.randomevents.listeners;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.immortalman01.randomevents.RandomEvents;
+import com.immortalman01.randomevents.language.LanguageMessages;
+import com.immortalman01.randomevents.match.Match;
+import com.immortalman01.randomevents.match.enums.Creacion;
+
+public class ChatPlayerCountTest {
+    private Chat chat;
+    private RandomEvents plugin;
+    private Player player;
+    private LanguageMessages lang;
+    private Map<String, Match> matches;
+    private Map<String, Integer> creation;
+    private List<String> messages;
+
+    @BeforeEach
+    public void setup() {
+        plugin = Mockito.mock(RandomEvents.class, Mockito.RETURNS_DEEP_STUBS);
+        chat = new Chat(plugin);
+        lang = Mockito.mock(LanguageMessages.class);
+        Mockito.when(plugin.getLanguage()).thenReturn(lang);
+        Mockito.when(lang.getInvalidInput()).thenReturn("invalid");
+        matches = new HashMap<>();
+        creation = new HashMap<>();
+        Mockito.when(plugin.getPlayerMatches()).thenReturn(matches);
+        Mockito.when(plugin.getPlayersCreation()).thenReturn(creation);
+
+        player = Mockito.mock(Player.class);
+        Mockito.when(player.getName()).thenReturn("p");
+        messages = new ArrayList<>();
+        Mockito.doAnswer(inv -> { messages.add(inv.getArgument(0)); return null; }).when(player).sendMessage(Mockito.anyString());
+    }
+
+    private void invoke(String msg, int step) throws Exception {
+        Method m = Chat.class.getDeclaredMethod("checkMessageCreation", String.class, Player.class, Integer.class);
+        m.setAccessible(true);
+        creation.put("p", step);
+        matches.putIfAbsent("p", new Match());
+        m.invoke(chat, msg, player, step);
+    }
+
+    @Test
+    public void validMaxPlayers() throws Exception {
+        invoke("10", Creacion.AMOUNT_PLAYERS.getPosition());
+        Match m = matches.get("p");
+        assertEquals(10, m.getAmountPlayers());
+        assertFalse(creation.containsKey("p"));
+        assertFalse(messages.isEmpty());
+        assertNotEquals("invalid", messages.get(0));
+    }
+
+    @Test
+    public void validMinPlayers() throws Exception {
+        Match m = new Match();
+        m.setAmountPlayers(10);
+        matches.put("p", m);
+        invoke("5", Creacion.AMOUNT_PLAYERS_MIN.getPosition());
+        assertEquals(5, m.getAmountPlayersMin());
+        assertFalse(creation.containsKey("p"));
+        assertFalse(messages.isEmpty());
+        assertNotEquals("invalid", messages.get(0));
+    }
+
+    @Test
+    public void invalidMaxPlayers() throws Exception {
+        invoke("0", Creacion.AMOUNT_PLAYERS.getPosition());
+        Match m = matches.get("p");
+        assertNull(m.getAmountPlayers());
+        assertTrue(creation.containsKey("p"));
+        assertEquals("invalid", messages.get(0));
+        assertEquals(2, messages.size());
+    }
+
+    @Test
+    public void invalidMinPlayersTooHigh() throws Exception {
+        Match m = new Match();
+        m.setAmountPlayers(5);
+        matches.put("p", m);
+        invoke("6", Creacion.AMOUNT_PLAYERS_MIN.getPosition());
+        assertNull(m.getAmountPlayersMin());
+        assertTrue(creation.containsKey("p"));
+        assertEquals("invalid", messages.get(0));
+        assertEquals(2, messages.size());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure player count inputs are positive and valid
- add Mockito and spigot API for unit tests
- test valid and invalid player limits

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68538f1bd8508330a2a20992d9267349