### PR TITLE
Clean up TODO catch blocks

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
@@ -479,10 +479,9 @@ public class LanguageMessages {
 		try {
 			method = this.getClass().getMethod(getComandoGet(javaField));
 			res = (String) method.invoke(this);
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+                } catch (Exception e) {
+                        plugin.getLoggerP().warning(e.toString());
+                }
 		return res;
 	}
 

--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
@@ -336,10 +336,9 @@ public class Use implements Listener {
 								Location loc = player.getLocation();
 								loc.setY(loc.getY() + 1);
 								XParticle.line(loc, locEnd, 0.5, pa);
-							} catch (Exception e) {
-								// TODO Auto-generated catch block
-								e.printStackTrace();
-							}
+                                                        } catch (Exception e) {
+                                                                plugin.getLoggerP().warning(e.toString());
+                                                        }
 						}
 					}
 

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -1535,10 +1535,9 @@ public class MatchActive {
 
 			res = (List<String>) method.invoke(plugin.getLanguage());
 
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+                } catch (Exception e) {
+                        plugin.getLoggerP().warning(e.toString());
+                }
 		return res;
 	}
 


### PR DESCRIPTION
## Summary
- log errors instead of stack traces in Use listener, MatchActive, and LanguageMessages
- remove leftover TODO comments

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6853976521a08330b6a3427b5395d19c