### PR TITLE
Fix spawn-step checks for missing counts

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -783,40 +783,46 @@ public class Chat implements Listener {
 
 						}
 						break;
-					case ARENA_SPAWNS:
-						if (message.equalsIgnoreCase(Constantes.DONE)) {
-							if (match.getSpawns().size() != match.getAmountPlayers()) {
+                                        case ARENA_SPAWNS:
+                                                if (match.getAmountPlayers() == null) {
+                                                        player.sendMessage(plugin.getLanguage().getLacksInfoCreation());
+                                                        actua = Boolean.FALSE;
+                                                } else if (message.equalsIgnoreCase(Constantes.DONE)) {
+                                                        if (match.getSpawns().size() != match.getAmountPlayers()) {
 
-								match.getSpawns().add(player.getLocation());
-								if (match.getSpawns().size() == match.getAmountPlayers()) {
-									plugin.getPlayersCreation().remove(player.getName());
+                                                                match.getSpawns().add(player.getLocation());
+                                                                if (match.getSpawns().size() == match.getAmountPlayers()) {
+                                                                        plugin.getPlayersCreation().remove(player.getName());
 
-								} else {
-									plugin.getPlayersCreation().put(player.getName(),
-											Creacion.ANOTHER_ARENA_SPAWNS.getPosition());
-									actua = Boolean.FALSE;
-								}
-							}
-						} else if (message.equalsIgnoreCase(Constantes.NEXT)) {
-							plugin.getPlayersCreation().remove(player.getName());
-						}
-						break;
-					case TEAM_SPAWNS:
-						if (message.equalsIgnoreCase(Constantes.DONE)) {
-							if (match.getSpawns().size() != match.getNumberOfTeams()) {
+                                                                } else {
+                                                                        plugin.getPlayersCreation().put(player.getName(),
+                                                                               Creacion.ANOTHER_ARENA_SPAWNS.getPosition());
+                                                                        actua = Boolean.FALSE;
+                                                                }
+                                                        }
+                                                } else if (message.equalsIgnoreCase(Constantes.NEXT)) {
+                                                        plugin.getPlayersCreation().remove(player.getName());
+                                                }
+                                                break;
+                                        case TEAM_SPAWNS:
+                                                if (match.getNumberOfTeams() == null) {
+                                                        player.sendMessage(plugin.getLanguage().getLacksInfoCreation());
+                                                        actua = Boolean.FALSE;
+                                                } else if (message.equalsIgnoreCase(Constantes.DONE)) {
+                                                        if (match.getSpawns().size() != match.getNumberOfTeams()) {
 
-								match.getSpawns().add(player.getLocation());
-								if (match.getSpawns().size() == match.getNumberOfTeams()) {
-									plugin.getPlayersCreation().remove(player.getName());
+                                                                match.getSpawns().add(player.getLocation());
+                                                                if (match.getSpawns().size() == match.getNumberOfTeams()) {
+                                                                        plugin.getPlayersCreation().remove(player.getName());
 
-								} else {
-									plugin.getPlayersCreation().put(player.getName(),
-											Creacion.ANOTHER_TEAM_SPAWNS.getPosition());
-									actua = Boolean.FALSE;
-								}
-							}
-						}
-						break;
+                                                                } else {
+                                                                        plugin.getPlayersCreation().put(player.getName(),
+                                                                               Creacion.ANOTHER_TEAM_SPAWNS.getPosition());
+                                                                        actua = Boolean.FALSE;
+                                                                }
+                                                        }
+                                                }
+                                                break;
 					case CANNON_SPAWNS:
 						if (message.equalsIgnoreCase(Constantes.DONE)) {
 
@@ -830,42 +836,48 @@ public class Chat implements Listener {
 						}
 
 						break;
-					case ENTITY_SPAWNS:
-						if (message.equalsIgnoreCase(Constantes.DONE)) {
-							if (match.getEntitySpawns().size() != match.getAmountPlayers()) {
+                                        case ENTITY_SPAWNS:
+                                                if (match.getAmountPlayers() == null) {
+                                                        player.sendMessage(plugin.getLanguage().getLacksInfoCreation());
+                                                        actua = Boolean.FALSE;
+                                                } else if (message.equalsIgnoreCase(Constantes.DONE)) {
+                                                        if (match.getEntitySpawns().size() != match.getAmountPlayers()) {
 
-								match.getEntitySpawns().add(player.getLocation());
-								if (match.getEntitySpawns().size() == match.getAmountPlayers()) {
-									plugin.getPlayersCreation().remove(player.getName());
+                                                                match.getEntitySpawns().add(player.getLocation());
+                                                                if (match.getEntitySpawns().size() == match.getAmountPlayers()) {
+                                                                        plugin.getPlayersCreation().remove(player.getName());
 
-								} else {
-									plugin.getPlayersCreation().put(player.getName(),
-											Creacion.ANOTHER_ENTITY_SPAWNS.getPosition());
-									actua = Boolean.FALSE;
+                                                                } else {
+                                                                        plugin.getPlayersCreation().put(player.getName(),
+                                                                               Creacion.ANOTHER_ENTITY_SPAWNS.getPosition());
+                                                                        actua = Boolean.FALSE;
 
-								}
-							}
-						} else if (message.equalsIgnoreCase(Constantes.NEXT)) {
+                                                                }
+                                                        }
+                                                } else if (message.equalsIgnoreCase(Constantes.NEXT)) {
 
-							plugin.getPlayersCreation().remove(player.getName());
+                                                        plugin.getPlayersCreation().remove(player.getName());
 
-						}
-						break;
-					case ANOTHER_ENTITY_SPAWNS:
-						if (message.equalsIgnoreCase(Constantes.DONE)) {
-							match.getEntitySpawns().add(player.getLocation());
-							if (match.getEntitySpawns().size() == match.getAmountPlayers()) {
-								plugin.getPlayersCreation().remove(player.getName());
+                                                }
+                                                break;
+                                        case ANOTHER_ENTITY_SPAWNS:
+                                                if (match.getAmountPlayers() == null) {
+                                                        player.sendMessage(plugin.getLanguage().getLacksInfoCreation());
+                                                        actua = Boolean.FALSE;
+                                                } else if (message.equalsIgnoreCase(Constantes.DONE)) {
+                                                        match.getEntitySpawns().add(player.getLocation());
+                                                        if (match.getEntitySpawns().size() == match.getAmountPlayers()) {
+                                                                plugin.getPlayersCreation().remove(player.getName());
 
-							} else {
+                                                        } else {
 
-								plugin.getPlayersCreation().put(player.getName(),
-										Creacion.ANOTHER_ENTITY_SPAWNS.getPosition());
-								actua = Boolean.FALSE;
+                                                                plugin.getPlayersCreation().put(player.getName(),
+                                                                               Creacion.ANOTHER_ENTITY_SPAWNS.getPosition());
+                                                                actua = Boolean.FALSE;
 
-							}
-						}
-						break;
+                                                        }
+                                                }
+                                                break;
 					case COMMANDS_ON_START_OPTIONAL:
 						if (message.equalsIgnoreCase(Constantes.DONE)) {
 							plugin.getPlayersCreation().remove(player.getName());
@@ -896,23 +908,26 @@ public class Chat implements Listener {
 							actua = Boolean.FALSE;
 						}
 						break;
-					case ANOTHER_ARENA_SPAWNS:
-						if (message.equalsIgnoreCase(Constantes.DONE)) {
-							match.getSpawns().add(player.getLocation());
-							if (match.getSpawns().size() == match.getAmountPlayers()) {
-								plugin.getPlayersCreation().remove(player.getName());
+                                        case ANOTHER_ARENA_SPAWNS:
+                                                if (match.getAmountPlayers() == null) {
+                                                        player.sendMessage(plugin.getLanguage().getLacksInfoCreation());
+                                                        actua = Boolean.FALSE;
+                                                } else if (message.equalsIgnoreCase(Constantes.DONE)) {
+                                                        match.getSpawns().add(player.getLocation());
+                                                        if (match.getSpawns().size() == match.getAmountPlayers()) {
+                                                                plugin.getPlayersCreation().remove(player.getName());
 
-							} else {
+                                                        } else {
 
-								plugin.getPlayersCreation().put(player.getName(),
-										Creacion.ANOTHER_ARENA_SPAWNS.getPosition());
-								actua = Boolean.FALSE;
+                                                                plugin.getPlayersCreation().put(player.getName(),
+                                                                               Creacion.ANOTHER_ARENA_SPAWNS.getPosition());
+                                                                actua = Boolean.FALSE;
 
-							}
-						} else if (message.equalsIgnoreCase(Constantes.NEXT)) {
-							plugin.getPlayersCreation().remove(player.getName());
-						}
-						break;
+                                                        }
+                                                } else if (message.equalsIgnoreCase(Constantes.NEXT)) {
+                                                        plugin.getPlayersCreation().remove(player.getName());
+                                                }
+                                                break;
 
 					case ANOTHER_TEAM_SPAWNS:
 						if (message.equalsIgnoreCase(Constantes.DONE)) {

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatSpawnMissingCountTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatSpawnMissingCountTest.java
@@ -1,0 +1,77 @@
+package com.immortalman01.randomevents.listeners;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.immortalman01.randomevents.RandomEvents;
+import com.immortalman01.randomevents.language.LanguageMessages;
+import com.immortalman01.randomevents.match.Match;
+import com.immortalman01.randomevents.match.enums.Creacion;
+
+public class ChatSpawnMissingCountTest {
+    private Chat chat;
+    private RandomEvents plugin;
+    private Player player;
+    private LanguageMessages lang;
+    private Map<String, Match> matches;
+    private Map<String, Integer> creation;
+    private List<String> messages;
+
+    @BeforeEach
+    public void setup() {
+        plugin = Mockito.mock(RandomEvents.class, Mockito.RETURNS_DEEP_STUBS);
+        chat = new Chat(plugin);
+        lang = Mockito.mock(LanguageMessages.class);
+        Mockito.when(plugin.getLanguage()).thenReturn(lang);
+        Mockito.when(lang.getLacksInfoCreation()).thenReturn("lack");
+        matches = new HashMap<>();
+        creation = new HashMap<>();
+        Mockito.when(plugin.getPlayerMatches()).thenReturn(matches);
+        Mockito.when(plugin.getPlayersCreation()).thenReturn(creation);
+
+        player = Mockito.mock(Player.class);
+        Mockito.when(player.getName()).thenReturn("p");
+        messages = new ArrayList<>();
+        Mockito.doAnswer(inv -> { messages.add(inv.getArgument(0)); return null; }).when(player).sendMessage(Mockito.anyString());
+    }
+
+    private void invoke(String msg, int step) throws Exception {
+        Method m = Chat.class.getDeclaredMethod("checkMessageCreation", String.class, Player.class, Integer.class);
+        m.setAccessible(true);
+        creation.put("p", step);
+        matches.putIfAbsent("p", new Match());
+        m.invoke(chat, msg, player, step);
+    }
+
+    @Test
+    public void missingMaxPlayersArenaSpawns() throws Exception {
+        invoke("Done", Creacion.ARENA_SPAWNS.getPosition());
+        assertEquals("lack", messages.get(0));
+        assertTrue(creation.containsKey("p"));
+        assertTrue(matches.get("p").getSpawns().isEmpty());
+    }
+
+    @Test
+    public void missingMaxPlayersEntitySpawns() throws Exception {
+        invoke("Done", Creacion.ENTITY_SPAWNS.getPosition());
+        assertEquals("lack", messages.get(0));
+        assertTrue(creation.containsKey("p"));
+    }
+
+    @Test
+    public void missingTeamsTeamSpawns() throws Exception {
+        invoke("Done", Creacion.TEAM_SPAWNS.getPosition());
+        assertEquals("lack", messages.get(0));
+        assertTrue(creation.containsKey("p"));
+    }
+}


### PR DESCRIPTION
## Summary
- avoid NullPointerException when spawn steps run without player/team counts
- warn player about missing info instead
- add regression tests for missing count handling

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685399ac2ff0833087005d2b647f47a7