### PR TITLE
Fix Match equality check for material

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
@@ -2,6 +2,7 @@ package com.immortalman01.randomevents.match;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -477,8 +478,8 @@ public class Match implements Comparable<Match> {
 				return false;
 		} else if (!location2.equals(other.location2))
 			return false;
-		if (material != other.material)
-			return false;
+               if (!Objects.equals(material, other.material))
+                       return false;
 		if (minigame != other.minigame)
 			return false;
 		if (mob != other.mob)


### PR DESCRIPTION
## Summary
- compare material Strings using `Objects.equals`
- add missing `Objects` import

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68539d3cea80833086ed5dcfca55b9f3