### PR TITLE
Handle null values in Match.compareTo

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
@@ -532,11 +532,26 @@ public class Match implements Comparable<Match> {
 		return true;
 	}
 
-	@Override
-	public int compareTo(Match match) {
+        @Override
+        public int compareTo(Match match) {
 
-		return Integer.valueOf(minigame.ordinal()).compareTo(Integer.valueOf(match.getMinigame().ordinal()));
-	}
+                Objects.requireNonNull(match, "match");
+
+                MinigameType thisGame = this.minigame;
+                MinigameType otherGame = match.getMinigame();
+
+                if (thisGame == null && otherGame == null) {
+                        return 0;
+                }
+                if (thisGame == null) {
+                        return -1;
+                }
+                if (otherGame == null) {
+                        return 1;
+                }
+
+                return Integer.valueOf(thisGame.ordinal()).compareTo(Integer.valueOf(otherGame.ordinal()));
+        }
 
 	public Integer getNumberOfTeams() {
 		return numberOfTeams;

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/match/MatchCompareToTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/match/MatchCompareToTest.java
@@ -1,0 +1,50 @@
+package com.immortalman01.randomevents.match;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.immortalman01.randomevents.match.enums.MinigameType;
+
+public class MatchCompareToTest {
+
+    @Test
+    public void compareHandlesBothNull() {
+        Match m1 = new Match();
+        Match m2 = new Match();
+        assertEquals(0, m1.compareTo(m2));
+    }
+
+    @Test
+    public void compareHandlesLeftNull() {
+        Match m1 = new Match();
+        Match m2 = new Match();
+        m2.setMinigame(MinigameType.TNT_RUN);
+        assertEquals(-1, m1.compareTo(m2));
+    }
+
+    @Test
+    public void compareHandlesRightNull() {
+        Match m1 = new Match();
+        m1.setMinigame(MinigameType.TNT_RUN);
+        Match m2 = new Match();
+        assertEquals(1, m1.compareTo(m2));
+    }
+
+    @Test
+    public void compareHandlesBothNonNull() {
+        Match m1 = new Match();
+        Match m2 = new Match();
+        m1.setMinigame(MinigameType.BATTLE_ROYALE);
+        m2.setMinigame(MinigameType.TNT_RUN);
+        int expected = Integer.compare(MinigameType.BATTLE_ROYALE.ordinal(), MinigameType.TNT_RUN.ordinal());
+        assertEquals(expected, m1.compareTo(m2));
+    }
+
+    @Test
+    public void compareNullArgument() {
+        Match m1 = new Match();
+        assertThrows(NullPointerException.class, () -> m1.compareTo(null));
+    }
+}


### PR DESCRIPTION
## Summary
- improve null-handling logic in `Match.compareTo`
- add unit tests verifying compareTo behavior with null minigames

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68539f1f6c2083309089345a6aa36f16