### PR TITLE
Fix teleport log message

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -867,12 +867,12 @@ public class UtilsRandomEvents {
 		if (!comprueba || !plugin.getReventConfig().getUseLastLocation()) {
 
 			if (loc != null) {
-				if (plugin.getReventConfig().isDebugMode()) {
-					plugin.getLogger()
-							.info("Teleporting to: X:" + loc.getX() + ", Y: " + loc.getY() + ", Z: " + loc.getZ()
-									+ ", World: " + loc.getWorld() + ", World Name: " + loc.getWorld() == null
-											? "NullWorld" : loc.getWorld().getName());
-				}
+                                if (plugin.getReventConfig().isDebugMode()) {
+                                        plugin.getLogger()
+                                                        .info("Teleporting to: X:" + loc.getX() + ", Y: " + loc.getY() + ", Z: " + loc.getZ()
+                                                                        + ", World: " + loc.getWorld() + ", World Name: "
+                                                                        + (loc.getWorld() == null ? "NullWorld" : loc.getWorld().getName()));
+                                }
 				p.setVelocity(new Vector(0, 0, 0));
 				try {
 					p.teleport(loc);


### PR DESCRIPTION
## Summary
- fix log message in teleportaPlayer to properly use ternary for world name

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_6853a1a34dec8330988d3335b729c451