### PR TITLE
Add dedicated timer fields to Match

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -1143,7 +1143,14 @@ public class Chat implements Listener {
 							MinigameType minigame = MinigameType.values()[Integer.valueOf(message)];
 							if (minigame != null) {
 								match.setMinigame(minigame);
-								match.setSecondsMobSpawn(null);
+                                                                match.setSecondsMobSpawn(null);
+                                                                match.setMobSpawnTimer(null);
+                                                                match.setArrowSpawnTimer(null);
+                                                                match.setAnvilSpawnTimer(null);
+                                                                match.setGemSpawnTimer(null);
+                                                                match.setBombTimer(null);
+                                                                match.setWarmupTime(null);
+                                                                match.setSecondsToSpawnBeast(null);
 								match.setMob(null);
 								match.setEntitySpawns(new ArrayList<Location>());
 								match.setTiempoPartida(null);
@@ -1208,7 +1215,7 @@ public class Chat implements Listener {
                                                 try {
                                                         double value = Double.parseDouble(message.trim());
                                                         if (value > 0) {
-                                                                match.setSecondsMobSpawn(value);
+                                                                match.setMobSpawnTimer(value);
                                                                 plugin.getPlayersCreation().remove(player.getName());
                                                         } else {
                                                                 player.sendMessage(plugin.getLanguage().getInvalidInput());
@@ -1495,7 +1502,28 @@ public class Chat implements Listener {
                                                 try {
                                                         double val = Double.parseDouble(message.trim());
                                                         if (val > 0) {
-                                                                match.setSecondsMobSpawn(val);
+                                                                switch (c) {
+                                                                case TIMER_ARROW_SPAWN:
+                                                                        match.setArrowSpawnTimer(val);
+                                                                        break;
+                                                                case TIMER_ANVIL_SPAWN:
+                                                                        match.setAnvilSpawnTimer(val);
+                                                                        break;
+                                                                case TIMER_GEM_SPAWN:
+                                                                        match.setGemSpawnTimer(val);
+                                                                        break;
+                                                                case SECONDS_TO_SPAWN_BEAST:
+                                                                        match.setSecondsToSpawnBeast(val);
+                                                                        break;
+                                                                case TIMER_BOMB:
+                                                                        match.setBombTimer(val);
+                                                                        break;
+                                                                case WARMUP_TIME:
+                                                                        match.setWarmupTime(val);
+                                                                        break;
+                                                                default:
+                                                                        break;
+                                                                }
                                                                 plugin.getPlayersCreation().remove(player.getName());
                                                         } else {
                                                                 player.sendMessage(plugin.getLanguage().getInvalidInput());
@@ -1625,8 +1653,15 @@ public class Chat implements Listener {
 								match.setSpectatorSpawns(new ArrayList<Location>());
 								match.setRewards(new ArrayList<String>());
 								match.setInventory(null);
-								match.setSecondsMobSpawn(null);
-								match.setMob(null);
+                                                                match.setSecondsMobSpawn(null);
+                                                                match.setMobSpawnTimer(null);
+                                                                match.setArrowSpawnTimer(null);
+                                                                match.setAnvilSpawnTimer(null);
+                                                                match.setGemSpawnTimer(null);
+                                                                match.setBombTimer(null);
+                                                                match.setWarmupTime(null);
+                                                                match.setSecondsToSpawnBeast(null);
+                                                                match.setMob(null);
 								match.setEntitySpawns(new ArrayList<Location>());
 								match.setTiempoPartida(null);
 								match.setLocation1(null);
@@ -1674,13 +1709,24 @@ public class Chat implements Listener {
 							case KITS:
 								match.setKits(new ArrayList<String>());
 								break;
-							case TIMER_MOB_SPAWN:
-							case TIMER_ARROW_SPAWN:
-							case TIMER_GEM_SPAWN:
-							case TIMER_BOMB:
-							case SECONDS_TO_SPAWN_BEAST:
-								match.setSecondsMobSpawn(null);
-								break;
+                                                        case TIMER_MOB_SPAWN:
+                                                                match.setMobSpawnTimer(null);
+                                                                break;
+                                                        case TIMER_ARROW_SPAWN:
+                                                                match.setArrowSpawnTimer(null);
+                                                                break;
+                                                        case TIMER_GEM_SPAWN:
+                                                                match.setGemSpawnTimer(null);
+                                                                break;
+                                                        case TIMER_BOMB:
+                                                                match.setBombTimer(null);
+                                                                break;
+                                                        case SECONDS_TO_SPAWN_BEAST:
+                                                                match.setSecondsToSpawnBeast(null);
+                                                                break;
+                                                        case WARMUP_TIME:
+                                                                match.setWarmupTime(null);
+                                                                break;
 							case MOB_NAME:
 								match.setMob(null);
 								break;

--- a/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
@@ -33,9 +33,18 @@ public class Match implements Comparable<Match> {
 
 	private List<Location> entitySpawns;
 
-	private List<Location> spectatorSpawns;
+        private List<Location> spectatorSpawns;
 
-	private Double secondsMobSpawn;
+        /** Legacy timer shared by multiple minigames. */
+        private Double secondsMobSpawn;
+
+        private Double mobSpawnTimer;
+        private Double arrowSpawnTimer;
+        private Double anvilSpawnTimer;
+        private Double gemSpawnTimer;
+        private Double bombTimer;
+        private Double warmupTime;
+        private Double secondsToSpawnBeast;
 
 	private Integer secondsToBegin;
 
@@ -193,9 +202,65 @@ public class Match implements Comparable<Match> {
 		return secondsMobSpawn;
 	}
 
-	public void setSecondsMobSpawn(Double secondsMobSpawn) {
-		this.secondsMobSpawn = secondsMobSpawn;
-	}
+        public void setSecondsMobSpawn(Double secondsMobSpawn) {
+                this.secondsMobSpawn = secondsMobSpawn;
+        }
+
+        public Double getMobSpawnTimer() {
+                return mobSpawnTimer;
+        }
+
+        public void setMobSpawnTimer(Double mobSpawnTimer) {
+                this.mobSpawnTimer = mobSpawnTimer;
+        }
+
+        public Double getArrowSpawnTimer() {
+                return arrowSpawnTimer;
+        }
+
+        public void setArrowSpawnTimer(Double arrowSpawnTimer) {
+                this.arrowSpawnTimer = arrowSpawnTimer;
+        }
+
+        public Double getAnvilSpawnTimer() {
+                return anvilSpawnTimer;
+        }
+
+        public void setAnvilSpawnTimer(Double anvilSpawnTimer) {
+                this.anvilSpawnTimer = anvilSpawnTimer;
+        }
+
+        public Double getGemSpawnTimer() {
+                return gemSpawnTimer;
+        }
+
+        public void setGemSpawnTimer(Double gemSpawnTimer) {
+                this.gemSpawnTimer = gemSpawnTimer;
+        }
+
+        public Double getBombTimer() {
+                return bombTimer;
+        }
+
+        public void setBombTimer(Double bombTimer) {
+                this.bombTimer = bombTimer;
+        }
+
+        public Double getWarmupTime() {
+                return warmupTime;
+        }
+
+        public void setWarmupTime(Double warmupTime) {
+                this.warmupTime = warmupTime;
+        }
+
+        public Double getSecondsToSpawnBeast() {
+                return secondsToSpawnBeast;
+        }
+
+        public void setSecondsToSpawnBeast(Double secondsToSpawnBeast) {
+                this.secondsToSpawnBeast = secondsToSpawnBeast;
+        }
 
 	public Location getEventSpawn() {
 		return eventSpawn;

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -177,9 +177,9 @@ public class MatchActive {
 		this.pets = new HashMap<String, Entity>();
 		this.puntuacion = new HashMap<String, Integer>();
 		switch (match.getMinigame()) {
-		case BOMB_TAG:
-			this.numeroSegRestantes = match.getSecondsMobSpawn().intValue();
-			break;
+                case BOMB_TAG:
+                        this.numeroSegRestantes = match.getBombTimer().intValue();
+                        break;
 		case BOAT_RUN:
 		case HORSE_RUN:
 		case RACE:
@@ -272,9 +272,9 @@ public class MatchActive {
 
 		this.puntuacion = new HashMap<String, Integer>();
 		switch (match.getMinigame()) {
-		case BOMB_TAG:
-			this.numeroSegRestantes = match.getSecondsMobSpawn().intValue();
-			break;
+                case BOMB_TAG:
+                        this.numeroSegRestantes = match.getBombTimer().intValue();
+                        break;
 		case BOAT_RUN:
 		case HORSE_RUN:
 		case RACE:
@@ -3078,43 +3078,43 @@ public class MatchActive {
 
 				setAllowMove(true);
 
-				UtilsRandomEvents.mandaMensaje(plugin, getPlayerHandler().getPlayersObj(), plugin.getLanguage()
-						.getWarmupEnd().replaceAll("%time%", "" + getMatch().getSecondsMobSpawn().longValue()), true);
+                                UtilsRandomEvents.mandaMensaje(plugin, getPlayerHandler().getPlayersObj(), plugin.getLanguage()
+                                                .getWarmupEnd().replaceAll("%time%", "" + getMatch().getWarmupTime().longValue()), true);
 
-				if (getMatch().getSecondsMobSpawn() > 3) {
-					Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new Runnable() {
-						public void run() {
+                                if (getMatch().getWarmupTime() > 3) {
+                                        Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new Runnable() {
+                                                public void run() {
 
-							UtilsRandomEvents.mandaMensaje(plugin, getPlayerHandler().getPlayersObj(),
-									plugin.getLanguage().getWarmupEnd().replaceAll("%time%", "3"), true);
-						}
-					}, 20 * (getMatch().getSecondsMobSpawn().longValue() - 3));
-					Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new Runnable() {
-						public void run() {
+                                                        UtilsRandomEvents.mandaMensaje(plugin, getPlayerHandler().getPlayersObj(),
+                                                                        plugin.getLanguage().getWarmupEnd().replaceAll("%time%", "3"), true);
+                                                }
+                                        }, 20 * (getMatch().getWarmupTime().longValue() - 3));
+                                        Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new Runnable() {
+                                                public void run() {
 
-							UtilsRandomEvents.mandaMensaje(plugin, getPlayerHandler().getPlayersObj(),
-									plugin.getLanguage().getWarmupEnd().replaceAll("%time%", "2"), true);
-						}
-					}, 20 * (getMatch().getSecondsMobSpawn().longValue() - 2));
-					Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new Runnable() {
-						public void run() {
+                                                        UtilsRandomEvents.mandaMensaje(plugin, getPlayerHandler().getPlayersObj(),
+                                                                        plugin.getLanguage().getWarmupEnd().replaceAll("%time%", "2"), true);
+                                                }
+                                        }, 20 * (getMatch().getWarmupTime().longValue() - 2));
+                                        Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new Runnable() {
+                                                public void run() {
 
-							UtilsRandomEvents.mandaMensaje(plugin, getPlayerHandler().getPlayersObj(),
-									plugin.getLanguage().getWarmupEnd().replaceAll("%time%", "1"), true);
-						}
-					}, 20 * (getMatch().getSecondsMobSpawn().longValue() - 1));
+                                                        UtilsRandomEvents.mandaMensaje(plugin, getPlayerHandler().getPlayersObj(),
+                                                                        plugin.getLanguage().getWarmupEnd().replaceAll("%time%", "1"), true);
+                                                }
+                                        }, 20 * (getMatch().getWarmupTime().longValue() - 1));
 
-				}
+                                }
 
-				Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new Runnable() {
+                                Bukkit.getScheduler().runTaskLaterAsynchronously(plugin, new Runnable() {
 
-					public void run() {
+                                        public void run() {
 
-						setAllowDamage(true);
-						setAllowDamagePVP(true);
-					}
+                                                setAllowDamage(true);
+                                                setAllowDamagePVP(true);
+                                        }
 
-				}, 20 * getMatch().getSecondsMobSpawn().longValue());
+                                }, 20 * getMatch().getWarmupTime().longValue());
 
 			}
 		}, 20 * getMatch().getSecondsToBegin().longValue());
@@ -3157,7 +3157,7 @@ public class MatchActive {
 	private void partidaBombTag() {
 
 		if (getPlaying()) {
-			endDate = Double.valueOf(new Date().getTime() + 1000 * getMatch().getSecondsMobSpawn()).longValue();
+                        endDate = Double.valueOf(new Date().getTime() + 1000 * getMatch().getBombTimer()).longValue();
 			for (Player p : getPlayerHandler().getPlayersObj()) {
 				if (p.equals(getPlayerHandler().getPlayerContador())) {
 					if (plugin.getReventConfig().getTntTagSpeedHolder() > 0) {
@@ -3208,7 +3208,7 @@ public class MatchActive {
                         if (bomba == null) {
                                 if (getPlayerHandler().getPlayersObj().size() > limitPlayers) {
                                         bombRandom();
-                                        endDate = Double.valueOf(new Date().getTime() + 1000 * getMatch().getSecondsMobSpawn()).longValue();
+                                        endDate = Double.valueOf(new Date().getTime() + 1000 * getMatch().getBombTimer()).longValue();
                                 } else {
                                         compruebaPartida();
                                 }
@@ -3262,7 +3262,7 @@ public class MatchActive {
 				} else {
 					compruebaPartida();
 				}
-				endDate = Double.valueOf(new Date().getTime() + 1000 * getMatch().getSecondsMobSpawn()).longValue();
+                                endDate = Double.valueOf(new Date().getTime() + 1000 * getMatch().getBombTimer()).longValue();
 			} else {
 
 				if (dif > 5 && dif % 5 == 0) {
@@ -3280,8 +3280,8 @@ public class MatchActive {
 	}
 
 	private void spawneaGemas() {
-		if (getPlaying()) {
-			Double timer = 20 * match.getSecondsMobSpawn();
+                if (getPlaying()) {
+                        Double timer = 20 * match.getGemSpawnTimer();
 
 			Bukkit.getServer().getScheduler().runTaskLaterAsynchronously((Plugin) getPlugin(), new Runnable() {
 				public void run() {
@@ -3303,8 +3303,8 @@ public class MatchActive {
 	}
 
 	public void partidaAnvilSpleef() {
-		if (getPlaying()) {
-			Double timer = 20 * match.getSecondsMobSpawn();
+                if (getPlaying()) {
+                        Double timer = 20 * match.getAnvilSpawnTimer();
 
 			Bukkit.getServer().getScheduler().runTaskLaterAsynchronously((Plugin) getPlugin(), new Runnable() {
 				public void run() {
@@ -3347,8 +3347,8 @@ public class MatchActive {
 	}
 
 	public void partidaBombardment() {
-		if (getPlaying()) {
-			Double timer = 20 * match.getSecondsMobSpawn();
+                if (getPlaying()) {
+                        Double timer = 20 * match.getBombTimer();
 
 			Bukkit.getServer().getScheduler().runTaskLaterAsynchronously((Plugin) getPlugin(), new Runnable() {
 				public void run() {
@@ -3396,8 +3396,8 @@ public class MatchActive {
 	}
 
 	public void partidaEscapeArrow() {
-		if (getPlaying()) {
-			Double timer = 20 * match.getSecondsMobSpawn();
+                if (getPlaying()) {
+                        Double timer = 20 * match.getArrowSpawnTimer();
 
 			Bukkit.getServer().getScheduler().runTaskLaterAsynchronously((Plugin) getPlugin(), new Runnable() {
 				public void run() {
@@ -3604,7 +3604,7 @@ public class MatchActive {
 			public void run() {
 				teleportaPlayer(p);
 			}
-		}, Double.valueOf(20 * plugin.getMatchActive().getMatch().getSecondsMobSpawn()).longValue());
+                }, Double.valueOf(20 * plugin.getMatchActive().getMatch().getSecondsToSpawnBeast()).longValue());
 
 	}
 

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilidadesJson.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilidadesJson.java
@@ -39,7 +39,22 @@ public class UtilidadesJson {
                 Match match = null;
                 try {
                         match = GSON.fromJson(br, Match.class);
-			UtilsRandomEvents.normalizaColorsMatch(match);
+                        UtilsRandomEvents.normalizaColorsMatch(match);
+
+                        if (match.getMobSpawnTimer() == null)
+                                match.setMobSpawnTimer(match.getSecondsMobSpawn());
+                        if (match.getArrowSpawnTimer() == null)
+                                match.setArrowSpawnTimer(match.getSecondsMobSpawn());
+                        if (match.getAnvilSpawnTimer() == null)
+                                match.setAnvilSpawnTimer(match.getSecondsMobSpawn());
+                        if (match.getGemSpawnTimer() == null)
+                                match.setGemSpawnTimer(match.getSecondsMobSpawn());
+                        if (match.getBombTimer() == null)
+                                match.setBombTimer(match.getSecondsMobSpawn());
+                        if (match.getWarmupTime() == null)
+                                match.setWarmupTime(match.getSecondsMobSpawn());
+                        if (match.getSecondsToSpawnBeast() == null)
+                                match.setSecondsToSpawnBeast(match.getSecondsMobSpawn());
 
 		} catch (Exception e) {
 			plugin.getLoggerP().info(e.getMessage());

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -2175,18 +2175,41 @@ public class UtilsRandomEvents {
 							}
 						}
 						break;
-					case TIMER_MOB_SPAWN:
-					case TIMER_ARROW_SPAWN:
-					case TIMER_ANVIL_SPAWN:
-					case TIMER_GEM_SPAWN:
-					case TIMER_BOMB:
-					case WARMUP_TIME:
-					case SECONDS_TO_SPAWN_BEAST:
-
-						if (match.getSecondsMobSpawn() != null) {
-							info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 " + match.getSecondsMobSpawn();
-						}
-						break;
+                                        case TIMER_MOB_SPAWN:
+                                                if (match.getMobSpawnTimer() != null) {
+                                                        info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 " + match.getMobSpawnTimer();
+                                                }
+                                                break;
+                                        case TIMER_ARROW_SPAWN:
+                                                if (match.getArrowSpawnTimer() != null) {
+                                                        info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 " + match.getArrowSpawnTimer();
+                                                }
+                                                break;
+                                        case TIMER_ANVIL_SPAWN:
+                                                if (match.getAnvilSpawnTimer() != null) {
+                                                        info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 " + match.getAnvilSpawnTimer();
+                                                }
+                                                break;
+                                        case TIMER_GEM_SPAWN:
+                                                if (match.getGemSpawnTimer() != null) {
+                                                        info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 " + match.getGemSpawnTimer();
+                                                }
+                                                break;
+                                        case TIMER_BOMB:
+                                                if (match.getBombTimer() != null) {
+                                                        info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 " + match.getBombTimer();
+                                                }
+                                                break;
+                                        case WARMUP_TIME:
+                                                if (match.getWarmupTime() != null) {
+                                                        info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 " + match.getWarmupTime();
+                                                }
+                                                break;
+                                        case SECONDS_TO_SPAWN_BEAST:
+                                                if (match.getSecondsToSpawnBeast() != null) {
+                                                        info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 " + match.getSecondsToSpawnBeast();
+                                                }
+                                                break;
 					case MOB_NAME:
 						if (match.getMob() != null) {
 							info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 " + match.getMob();
@@ -2413,18 +2436,41 @@ public class UtilsRandomEvents {
 					res = Boolean.FALSE;
 				}
 				break;
-			case TIMER_MOB_SPAWN:
-			case TIMER_ARROW_SPAWN:
-			case TIMER_ANVIL_SPAWN:
-			case TIMER_GEM_SPAWN:
-			case TIMER_BOMB:
-			case WARMUP_TIME:
-			case SECONDS_TO_SPAWN_BEAST:
-
-				if (match.getSecondsMobSpawn() == null) {
-					res = Boolean.FALSE;
-				}
-				break;
+                        case TIMER_MOB_SPAWN:
+                                if (match.getMobSpawnTimer() == null) {
+                                        res = Boolean.FALSE;
+                                }
+                                break;
+                        case TIMER_ARROW_SPAWN:
+                                if (match.getArrowSpawnTimer() == null) {
+                                        res = Boolean.FALSE;
+                                }
+                                break;
+                        case TIMER_ANVIL_SPAWN:
+                                if (match.getAnvilSpawnTimer() == null) {
+                                        res = Boolean.FALSE;
+                                }
+                                break;
+                        case TIMER_GEM_SPAWN:
+                                if (match.getGemSpawnTimer() == null) {
+                                        res = Boolean.FALSE;
+                                }
+                                break;
+                        case TIMER_BOMB:
+                                if (match.getBombTimer() == null) {
+                                        res = Boolean.FALSE;
+                                }
+                                break;
+                        case WARMUP_TIME:
+                                if (match.getWarmupTime() == null) {
+                                        res = Boolean.FALSE;
+                                }
+                                break;
+                        case SECONDS_TO_SPAWN_BEAST:
+                                if (match.getSecondsToSpawnBeast() == null) {
+                                        res = Boolean.FALSE;
+                                }
+                                break;
 			case MOB_NAME:
 				if (match.getMob() == null) {
 					res = Boolean.FALSE;

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatTimerValidationTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatTimerValidationTest.java
@@ -85,13 +85,25 @@ public class ChatTimerValidationTest {
         Match m = matches.get("p");
         switch (c) {
             case TIMER_MOB_SPAWN:
+                assertNull(m.getMobSpawnTimer());
+                break;
             case TIMER_ARROW_SPAWN:
+                assertNull(m.getArrowSpawnTimer());
+                break;
             case TIMER_ANVIL_SPAWN:
+                assertNull(m.getAnvilSpawnTimer());
+                break;
             case TIMER_GEM_SPAWN:
+                assertNull(m.getGemSpawnTimer());
+                break;
             case SECONDS_TO_SPAWN_BEAST:
+                assertNull(m.getSecondsToSpawnBeast());
+                break;
             case TIMER_BOMB:
+                assertNull(m.getBombTimer());
+                break;
             case WARMUP_TIME:
-                assertNull(m.getSecondsMobSpawn());
+                assertNull(m.getWarmupTime());
                 break;
             case PLAY_TIME:
             case SHRINK_TIME:


### PR DESCRIPTION
## Summary
- add fields for individual timers in `Match`
- update Chat creation logic to use new fields
- show new timers in UtilsRandomEvents and validate them
- convert legacy `secondsMobSpawn` values in `UtilidadesJson`
- adjust gameplay classes and tests to the new timers

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6853a9d5e42c8330ba53f0720fc7fdc7