### PR TITLE
Fix kit creation when player is null

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -259,9 +259,9 @@ public class UtilsRandomEvents {
 
 	}
 
-	public static void terminaCreacionKit(RandomEvents plugin, Player player, Kit kit) {
-		if (kit == null)
-			kit = plugin.getPlayerKit().get(player.getName());
+       public static void terminaCreacionKit(RandomEvents plugin, Player player, Kit kit) {
+               if (kit == null && player != null)
+                       kit = plugin.getPlayerKit().get(player.getName());
 		try {
 			String json = UtilidadesJson.fromKitToJSON(plugin, kit);
 			if (json != null) {
@@ -288,9 +288,11 @@ public class UtilsRandomEvents {
 
 				pw.flush();
 
-				pw.close();
-				plugin.getPlayersCreationKit().remove(player.getName());
-                                plugin.getPlayerKit().remove(player.getName());
+                               pw.close();
+                               if (player != null) {
+                                       plugin.getPlayersCreationKit().remove(player.getName());
+                                       plugin.getPlayerKit().remove(player.getName());
+                               }
 
                                 Kit kitAux = null;
                                 for (Kit m : plugin.getKits()) {

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/util/TerminaCreacionKitNullPlayerTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/util/TerminaCreacionKitNullPlayerTest.java
@@ -1,0 +1,45 @@
+package com.immortalman01.randomevents.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.immortalman01.randomevents.RandomEvents;
+import com.immortalman01.randomevents.config.ReventConfig;
+import com.immortalman01.randomevents.match.Kit;
+
+public class TerminaCreacionKitNullPlayerTest {
+
+    @Test
+    public void conversionStepDoesNotThrow() throws Exception {
+        RandomEvents plugin = Mockito.mock(RandomEvents.class, Mockito.RETURNS_DEEP_STUBS);
+        File folder = Files.createTempDirectory("revent").toFile();
+        Mockito.when(plugin.getDataFolder()).thenReturn(folder);
+
+        ReventConfig cfg = Mockito.mock(ReventConfig.class);
+        Mockito.when(cfg.getUseEncoding()).thenReturn("UTF-8");
+        Mockito.when(plugin.getReventConfig()).thenReturn(cfg);
+
+        Mockito.when(plugin.getLoggerP()).thenReturn(Logger.getLogger("test"));
+        Mockito.when(plugin.getPlayersCreationKit()).thenReturn(new HashMap<>());
+        Mockito.when(plugin.getPlayerKit()).thenReturn(new HashMap<>());
+        List<Kit> kits = new ArrayList<>();
+        Mockito.when(plugin.getKits()).thenReturn(kits);
+
+        Kit kit = new Kit();
+        kit.setName("example");
+        kit.setItem(null);
+
+        assertDoesNotThrow(() -> UtilsRandomEvents.terminaCreacionKit(plugin, null, kit));
+        assertTrue(kits.contains(kit));
+    }
+}


### PR DESCRIPTION
## Summary
- skip player map removals in `terminaCreacionKit` when there is no player
- add regression test ensuring conversion step works without an active player

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6853b81b85e08330a26a1e054926ca5a