### PR TITLE
Handle invalid gamemode input

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -771,13 +771,17 @@ public class Chat implements Listener {
 							match.setGamemode(GameMode.CREATIVE);
 							plugin.getPlayersCreation().remove(player.getName());
 
-						} else if (message.equalsIgnoreCase("N")) {
-							plugin.getPlayersCreation().remove(player.getName());
+                                               } else if (message.equalsIgnoreCase("N")) {
+                                                        plugin.getPlayersCreation().remove(player.getName());
 
-						}
-						break;
-					case SPAWN_BEAST:
-						if (message.equalsIgnoreCase(Constantes.DONE)) {
+                                                } else {
+                                                        player.sendMessage(plugin.getLanguage().getInvalidInput());
+                                                        actua = Boolean.FALSE;
+
+                                                }
+                                                break;
+                                        case SPAWN_BEAST:
+                                                if (message.equalsIgnoreCase(Constantes.DONE)) {
 							match.setBeastSpawn(player.getLocation());
 							plugin.getPlayersCreation().remove(player.getName());
 


### PR DESCRIPTION
## Summary
- show invalid input messages if gamemode text isn't recognised

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6853bc6931988330a8981b7f4f490b6d