### PR TITLE
Remove debug printing from Configuration

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/config/Configuration.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/config/Configuration.java
@@ -44,7 +44,6 @@ public class Configuration extends CommentConfiguration {
         }
         catch(IOException e) {
             e.printStackTrace();
-            System.out.println("Attempting to fix error...");
             createData();
             saveData();
         }
@@ -80,15 +79,6 @@ public class Configuration extends CommentConfiguration {
         if(this.file.exists()) {
             this.file.delete();
         }
-    }
- 
-    public static void main(String[] args) {
-        Configuration cfg = new Configuration((JavaPlugin) null, "config.yml"); // You'd reference your JavaPlugin here, ofc
-
-        System.out.println(cfg.getInt("Test.path.integer"));
-   
-        cfg.set("Test.path.integer", 99);
-        cfg.saveData();
     }
 
 }


### PR DESCRIPTION
## Summary
- clean up configuration loader by removing debug `System.out.println` and the standalone `main` method

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6853bec6332883308833fce49ac39469