### PR TITLE
Handle null names in color normalization

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -1280,20 +1280,29 @@ public class UtilsRandomEvents {
 		return message.replaceAll("&", "<color>").replaceAll("§", "<color>");
 	}
 
-	public static void normalizaColorsMatch(Match match) {
-		match.setName(match.getName().replace("<color>", "§"));
+        public static void normalizaColorsMatch(Match match) {
+                if (match == null || match.getName() == null) {
+                        return;
+                }
+                match.setName(match.getName().replace("<color>", "§"));
 
-	}
+        }
 
-	public static void normalizaColorsWaterDrop(WaterDropStep match) {
-		match.setName(match.getName().replace("<color>", "§"));
+        public static void normalizaColorsWaterDrop(WaterDropStep match) {
+                if (match == null || match.getName() == null) {
+                        return;
+                }
+                match.setName(match.getName().replace("<color>", "§"));
 
-	}
+        }
 
-	public static void normalizaColorsKit(Kit match) {
-		match.setName(match.getName().replace("<color>", "§"));
+        public static void normalizaColorsKit(Kit match) {
+                if (match == null || match.getName() == null) {
+                        return;
+                }
+                match.setName(match.getName().replace("<color>", "§"));
 
-	}
+        }
 
 	public static List<Player> borraPlayerPorName(List<Player> players, Player player) {
 		Player p = null;

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/util/NormalizaColorsNullNameTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/util/NormalizaColorsNullNameTest.java
@@ -1,0 +1,38 @@
+package com.immortalman01.randomevents.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import com.immortalman01.randomevents.match.Match;
+import com.immortalman01.randomevents.match.WaterDropStep;
+import com.immortalman01.randomevents.match.Kit;
+
+/** Tests for UtilsRandomEvents#normalizaColors* with null names. */
+public class NormalizaColorsNullNameTest {
+
+    @Test
+    public void normalizeMatchNullName() {
+        Match m = new Match();
+        m.setName(null);
+        assertDoesNotThrow(() -> UtilsRandomEvents.normalizaColorsMatch(m));
+        assertNull(m.getName());
+    }
+
+    @Test
+    public void normalizeWaterDropNullName() {
+        WaterDropStep step = new WaterDropStep();
+        step.setName(null);
+        assertDoesNotThrow(() -> UtilsRandomEvents.normalizaColorsWaterDrop(step));
+        assertNull(step.getName());
+    }
+
+    @Test
+    public void normalizeKitNullName() {
+        Kit kit = new Kit();
+        kit.setName(null);
+        assertDoesNotThrow(() -> UtilsRandomEvents.normalizaColorsKit(kit));
+        assertNull(kit.getName());
+    }
+}


### PR DESCRIPTION
## Summary
- guard `normalizaColorsMatch`, `normalizaColorsWaterDrop`, and `normalizaColorsKit` against null names
- test that these utilities no longer throw when names are null

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6853c17cbeb883308bd8638c857ae45f