### PR TITLE
Fix seeker count validation

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -741,12 +741,23 @@ public class Chat implements Listener {
 
 						break;
 
-					case NUMBER_OF_SEEKERS:
-						Integer number2 = Integer.valueOf(message.trim());
-						match.setNumberOfSeekers(number2);
-						plugin.getPlayersCreation().remove(player.getName());
+                                        case NUMBER_OF_SEEKERS:
+                                                try {
+                                                        int seekers = Integer.parseInt(message.trim());
+                                                        Integer max = match.getAmountPlayers();
+                                                        if (seekers > 0 && (max == null || seekers <= max)) {
+                                                                match.setNumberOfSeekers(seekers);
+                                                                plugin.getPlayersCreation().remove(player.getName());
+                                                        } else {
+                                                                player.sendMessage(plugin.getLanguage().getInvalidInput());
+                                                                actua = Boolean.FALSE;
+                                                        }
+                                                } catch (Exception e) {
+                                                        player.sendMessage(plugin.getLanguage().getInvalidInput());
+                                                        actua = Boolean.FALSE;
+                                                }
 
-						break;
+                                                break;
 					case SPAWN_PLAYER:
 						if (message.equalsIgnoreCase(Constantes.DONE)) {
 							match.setPlayerSpawn(player.getLocation());

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatSeekerCountTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatSeekerCountTest.java
@@ -1,0 +1,99 @@
+package com.immortalman01.randomevents.listeners;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.immortalman01.randomevents.RandomEvents;
+import com.immortalman01.randomevents.language.LanguageMessages;
+import com.immortalman01.randomevents.match.Match;
+import com.immortalman01.randomevents.match.enums.Creacion;
+
+public class ChatSeekerCountTest {
+    private Chat chat;
+    private RandomEvents plugin;
+    private Player player;
+    private LanguageMessages lang;
+    private Map<String, Match> matches;
+    private Map<String, Integer> creation;
+    private List<String> messages;
+
+    @BeforeEach
+    public void setup() {
+        plugin = Mockito.mock(RandomEvents.class, Mockito.RETURNS_DEEP_STUBS);
+        chat = new Chat(plugin);
+        lang = Mockito.mock(LanguageMessages.class);
+        Mockito.when(plugin.getLanguage()).thenReturn(lang);
+        Mockito.when(lang.getInvalidInput()).thenReturn("invalid");
+        matches = new HashMap<>();
+        creation = new HashMap<>();
+        Mockito.when(plugin.getPlayerMatches()).thenReturn(matches);
+        Mockito.when(plugin.getPlayersCreation()).thenReturn(creation);
+
+        player = Mockito.mock(Player.class);
+        Mockito.when(player.getName()).thenReturn("p");
+        messages = new ArrayList<>();
+        Mockito.doAnswer(inv -> { messages.add(inv.getArgument(0)); return null; }).when(player).sendMessage(Mockito.anyString());
+    }
+
+    private void invoke(String msg, int step) throws Exception {
+        Method m = Chat.class.getDeclaredMethod("checkMessageCreation", String.class, Player.class, Integer.class);
+        m.setAccessible(true);
+        creation.put("p", step);
+        matches.putIfAbsent("p", new Match());
+        m.invoke(chat, msg, player, step);
+    }
+
+    @Test
+    public void validSeekersWithoutMax() throws Exception {
+        invoke("3", Creacion.NUMBER_OF_SEEKERS.getPosition());
+        Match m = matches.get("p");
+        assertEquals(3, m.getNumberOfSeekers());
+        assertFalse(creation.containsKey("p"));
+        assertFalse(messages.isEmpty());
+        assertNotEquals("invalid", messages.get(0));
+    }
+
+    @Test
+    public void validSeekersWithMax() throws Exception {
+        Match m = new Match();
+        m.setAmountPlayers(5);
+        matches.put("p", m);
+        invoke("2", Creacion.NUMBER_OF_SEEKERS.getPosition());
+        assertEquals(2, m.getNumberOfSeekers());
+        assertFalse(creation.containsKey("p"));
+        assertFalse(messages.isEmpty());
+        assertNotEquals("invalid", messages.get(0));
+    }
+
+    @Test
+    public void invalidSeekersZero() throws Exception {
+        invoke("0", Creacion.NUMBER_OF_SEEKERS.getPosition());
+        Match m = matches.get("p");
+        assertNull(m.getNumberOfSeekers());
+        assertTrue(creation.containsKey("p"));
+        assertEquals("invalid", messages.get(0));
+        assertEquals(2, messages.size());
+    }
+
+    @Test
+    public void invalidSeekersTooHigh() throws Exception {
+        Match m = new Match();
+        m.setAmountPlayers(2);
+        matches.put("p", m);
+        invoke("3", Creacion.NUMBER_OF_SEEKERS.getPosition());
+        assertNull(m.getNumberOfSeekers());
+        assertTrue(creation.containsKey("p"));
+        assertEquals("invalid", messages.get(0));
+        assertEquals(2, messages.size());
+    }
+}


### PR DESCRIPTION
## Summary
- validate NUMBER_OF_SEEKERS input in chat listener
- add tests for seeker count validation

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6853c2c12210833083b741782c9b9836