### PR TITLE
Handle null player and object in termination methods

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -145,9 +145,13 @@ public class UtilsRandomEvents {
 		terminaCreacionMatch(plugin, player, null);
 	}
 
-	public static void terminaCreacionMatch(RandomEvents plugin, Player player, Match match) {
-		if (match == null)
-			match = plugin.getPlayerMatches().get(player.getName());
+       public static void terminaCreacionMatch(RandomEvents plugin, Player player, Match match) {
+               if (match == null && player == null) {
+                       plugin.getLoggerP().warning("terminaCreacionMatch called with null player and null match");
+                       return;
+               }
+               if (match == null)
+                       match = plugin.getPlayerMatches().get(player.getName());
 		try {
 			String json = UtilidadesJson.fromMatchToJSON(plugin, match);
 			if (json != null) {
@@ -214,8 +218,15 @@ public class UtilsRandomEvents {
 
 	}
 
-	public static void terminaCreacionWD(RandomEvents plugin, Player player) {
-		WaterDropStep waterDrop = plugin.getPlayerWaterDrop().get(player.getName());
+       public static void terminaCreacionWD(RandomEvents plugin, Player player) {
+               WaterDropStep waterDrop = null;
+               if (player != null) {
+                       waterDrop = plugin.getPlayerWaterDrop().get(player.getName());
+               }
+               if (waterDrop == null && player == null) {
+                       plugin.getLoggerP().warning("terminaCreacionWD called with null player and null waterDrop");
+                       return;
+               }
 		try {
 			String json = UtilidadesJson.fromWDToJSON(plugin, waterDrop);
 			if (json != null) {
@@ -260,6 +271,10 @@ public class UtilsRandomEvents {
 	}
 
        public static void terminaCreacionKit(RandomEvents plugin, Player player, Kit kit) {
+               if (kit == null && player == null) {
+                       plugin.getLoggerP().warning("terminaCreacionKit called with null player and null kit");
+                       return;
+               }
                if (kit == null && player != null)
                        kit = plugin.getPlayerKit().get(player.getName());
 		try {

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/util/TerminaCreacionKitNullParamsTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/util/TerminaCreacionKitNullParamsTest.java
@@ -1,0 +1,19 @@
+package com.immortalman01.randomevents.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.immortalman01.randomevents.RandomEvents;
+
+public class TerminaCreacionKitNullParamsTest {
+    @Test
+    public void doesNotThrowWithNullPlayerAndKit() {
+        RandomEvents plugin = Mockito.mock(RandomEvents.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(plugin.getLoggerP()).thenReturn(Logger.getLogger("test"));
+        assertDoesNotThrow(() -> UtilsRandomEvents.terminaCreacionKit(plugin, null, null));
+    }
+}

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/util/TerminaCreacionMatchNullParamsTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/util/TerminaCreacionMatchNullParamsTest.java
@@ -1,0 +1,19 @@
+package com.immortalman01.randomevents.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.immortalman01.randomevents.RandomEvents;
+
+public class TerminaCreacionMatchNullParamsTest {
+    @Test
+    public void doesNotThrowWithNullPlayerAndMatch() {
+        RandomEvents plugin = Mockito.mock(RandomEvents.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(plugin.getLoggerP()).thenReturn(Logger.getLogger("test"));
+        assertDoesNotThrow(() -> UtilsRandomEvents.terminaCreacionMatch(plugin, null, null));
+    }
+}

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/util/TerminaCreacionWDNullParamsTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/util/TerminaCreacionWDNullParamsTest.java
@@ -1,0 +1,19 @@
+package com.immortalman01.randomevents.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.immortalman01.randomevents.RandomEvents;
+
+public class TerminaCreacionWDNullParamsTest {
+    @Test
+    public void doesNotThrowWithNullPlayerAndWaterDrop() {
+        RandomEvents plugin = Mockito.mock(RandomEvents.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(plugin.getLoggerP()).thenReturn(Logger.getLogger("test"));
+        assertDoesNotThrow(() -> UtilsRandomEvents.terminaCreacionWD(plugin, null));
+    }
+}


### PR DESCRIPTION
## Summary
- add null checks when finishing match/kit/waterdrop creation
- avoid writing files if both player and object are null
- test that termination methods handle null player and null match/kit/waterdrop

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6853f24b286c8330b0d78fbab57b0bc3