### PR TITLE
Add inventory check for Kit creation

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -190,28 +190,35 @@ public class Chat implements Listener {
 						}
 						break;
 					case INVENTORY:
-						if (message.equalsIgnoreCase(Constantes.DONE)) {
+                                                if (message.equalsIgnoreCase(Constantes.DONE)) {
+                                                        if (player.getInventory().getItemInMainHand() != null
+                                                                        && player.getInventory().getItemInMainHand()
+                                                                                        .getType() != (XMaterial.AIR.parseMaterial())) {
 
-							ItemStack[] contenido = player.getInventory().getContents();
-                                                        List<ItemStack> contenidoList = new ArrayList<>(Arrays.asList(contenido));
-							try {
-								contenidoList.removeAll(Arrays.asList(player.getInventory().getArmorContents()));
-							} catch (Exception e) {
+                                                                ItemStack[] contenido = player.getInventory().getContents();
+                                                                List<ItemStack> contenidoList = new ArrayList<>(Arrays.asList(contenido));
+                                                                try {
+                                                                        contenidoList.removeAll(Arrays.asList(player.getInventory().getArmorContents()));
+                                                                } catch (Exception e) {
 
-							}
-							ItemStack[] arrayContenido = new ItemStack[contenidoList.size()];
-							arrayContenido = contenidoList.toArray(arrayContenido);
-							InventoryPers inv = new InventoryPers();
-							inv.setContents(arrayContenido);
-							inv.setHelmet(player.getInventory().getHelmet());
-							inv.setBoots(player.getInventory().getBoots());
-							inv.setLeggings(player.getInventory().getLeggings());
-							inv.setChestplate(player.getInventory().getChestplate());
-							kit.setInventory(inv);
+                                                                }
+                                                                ItemStack[] arrayContenido = new ItemStack[contenidoList.size()];
+                                                                arrayContenido = contenidoList.toArray(arrayContenido);
+                                                                InventoryPers inv = new InventoryPers();
+                                                                inv.setContents(arrayContenido);
+                                                                inv.setHelmet(player.getInventory().getHelmet());
+                                                                inv.setBoots(player.getInventory().getBoots());
+                                                                inv.setLeggings(player.getInventory().getLeggings());
+                                                                inv.setChestplate(player.getInventory().getChestplate());
+                                                                kit.setInventory(inv);
 
-							plugin.getPlayersCreationKit().remove(player.getName());
+                                                                plugin.getPlayersCreationKit().remove(player.getName());
+                                                        } else {
+                                                                player.sendMessage(plugin.getLanguage().getInvalidInput());
+                                                                actua = Boolean.FALSE;
+                                                        }
 
-						}
+                                                }
 						break;
 
 					case SAVE:

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatKitInventoryEmptyHandTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatKitInventoryEmptyHandTest.java
@@ -1,0 +1,71 @@
+package com.immortalman01.randomevents.listeners;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.immortalman01.randomevents.RandomEvents;
+import com.immortalman01.randomevents.language.LanguageMessages;
+import com.immortalman01.randomevents.match.Kit;
+import com.immortalman01.randomevents.match.enums.CreacionKit;
+
+public class ChatKitInventoryEmptyHandTest {
+    private Chat chat;
+    private RandomEvents plugin;
+    private Player player;
+    private LanguageMessages lang;
+    private Map<String, Kit> kits;
+    private Map<String, Integer> creation;
+    private List<String> messages;
+
+    @BeforeEach
+    public void setup() {
+        plugin = Mockito.mock(RandomEvents.class, Mockito.RETURNS_DEEP_STUBS);
+        chat = new Chat(plugin);
+        lang = Mockito.mock(LanguageMessages.class);
+        Mockito.when(plugin.getLanguage()).thenReturn(lang);
+        Mockito.when(lang.getInvalidInput()).thenReturn("invalid");
+        kits = new HashMap<>();
+        creation = new HashMap<>();
+        Mockito.when(plugin.getPlayerKit()).thenReturn(kits);
+        Mockito.when(plugin.getPlayersCreationKit()).thenReturn(creation);
+
+        player = Mockito.mock(Player.class);
+        Mockito.when(player.getName()).thenReturn("p");
+        PlayerInventory inv = Mockito.mock(PlayerInventory.class);
+        Mockito.when(player.getInventory()).thenReturn(inv);
+        Mockito.when(inv.getItemInMainHand()).thenReturn(new ItemStack(Material.AIR));
+        messages = new ArrayList<>();
+        Mockito.doAnswer(a -> { messages.add(a.getArgument(0)); return null; }).when(player).sendMessage(Mockito.anyString());
+    }
+
+    private void invoke(String msg, int step) throws Exception {
+        Method m = Chat.class.getDeclaredMethod("checkMessageCreationKit", String.class, Player.class, Integer.class);
+        m.setAccessible(true);
+        creation.put("p", step);
+        kits.putIfAbsent("p", new Kit());
+        m.invoke(chat, msg, player, step);
+    }
+
+    @Test
+    public void emptyHandDoesNotSaveInventory() throws Exception {
+        invoke("Done", CreacionKit.INVENTORY.getPosition());
+        Kit kit = kits.get("p");
+        assertNull(kit.getInventory());
+        assertTrue(creation.containsKey("p"));
+        assertEquals("invalid", messages.get(0));
+        assertEquals(2, messages.size());
+    }
+}


### PR DESCRIPTION
## Summary
- verify player holds an item before copying kit inventory
- notify with `getInvalidInput` if empty handed
- add unit test to ensure inventory step is not finalized when no item in hand

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6853f396dd6c8330a054790eb7084caa