### PR TITLE
Handle repeated cannon spawn setup

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -867,6 +867,8 @@ public class Chat implements Listener {
                                                 if (message.equalsIgnoreCase(Constantes.DONE)) {
 
                                                         match.getEntitySpawns().add(player.getLocation());
+                                                        plugin.getPlayersCreation().put(player.getName(),
+                                                                        Creacion.CANNON_SPAWNS.getPosition());
                                                         actua = Boolean.FALSE;
 
                                                 } else if (message.equalsIgnoreCase(Constantes.NEXT)) {

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatCannonSpawnsLoopTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/ChatCannonSpawnsLoopTest.java
@@ -1,0 +1,73 @@
+package com.immortalman01.randomevents.listeners;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Method;
+import java.util.*;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.immortalman01.randomevents.RandomEvents;
+import com.immortalman01.randomevents.language.LanguageMessages;
+import com.immortalman01.randomevents.match.Match;
+import com.immortalman01.randomevents.match.enums.Creacion;
+
+public class ChatCannonSpawnsLoopTest {
+    private Chat chat;
+    private RandomEvents plugin;
+    private Player player;
+    private LanguageMessages lang;
+    private Map<String, Match> matches;
+    private Map<String, Integer> creation;
+    private List<String> messages;
+
+    @BeforeEach
+    public void setup() {
+        plugin = Mockito.mock(RandomEvents.class, Mockito.RETURNS_DEEP_STUBS);
+        chat = new Chat(plugin);
+        lang = Mockito.mock(LanguageMessages.class);
+        Mockito.when(plugin.getLanguage()).thenReturn(lang);
+        Mockito.when(lang.getInvalidInput()).thenReturn("invalid");
+        matches = new HashMap<>();
+        creation = new HashMap<>();
+        Mockito.when(plugin.getPlayerMatches()).thenReturn(matches);
+        Mockito.when(plugin.getPlayersCreation()).thenReturn(creation);
+
+        player = Mockito.mock(Player.class);
+        Mockito.when(player.getName()).thenReturn("p");
+        messages = new ArrayList<>();
+        Mockito.doAnswer(inv -> { messages.add(inv.getArgument(0)); return null; }).when(player).sendMessage(Mockito.anyString());
+    }
+
+    private void invoke(String msg) throws Exception {
+        Method m = Chat.class.getDeclaredMethod("checkMessageCreation", String.class, Player.class, Integer.class);
+        m.setAccessible(true);
+        Integer step = creation.get("p");
+        m.invoke(chat, msg, player, step);
+    }
+
+    @Test
+    public void multipleDoneBeforeNextStoresAllLocations() throws Exception {
+        creation.put("p", Creacion.CANNON_SPAWNS.getPosition());
+        Match match = new Match();
+        match.setEntitySpawns(new ArrayList<>());
+        matches.put("p", match);
+
+        invoke("Done");
+        assertEquals(1, match.getEntitySpawns().size());
+        assertEquals(Creacion.CANNON_SPAWNS.getPosition(), creation.get("p"));
+
+        invoke("Done");
+        assertEquals(2, match.getEntitySpawns().size());
+        assertEquals(Creacion.CANNON_SPAWNS.getPosition(), creation.get("p"));
+
+        invoke("Next");
+        assertEquals(2, match.getEntitySpawns().size());
+        assertFalse(creation.containsKey("p"));
+        assertFalse(messages.isEmpty());
+        assertNotEquals("invalid", messages.get(0));
+    }
+}


### PR DESCRIPTION
## Summary
- keep players in `CANNON_SPAWNS` step after each `Done`
- re-prompt players for additional cannon spawns until `Next`
- test that multiple `Done` messages store multiple locations

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6853f5db0d9883308bd166d5508e252a