### PR TITLE
Fix scoreboard refill string in Turkish

### DIFF
--- a/RandomEvents/messages_tr.yml
+++ b/RandomEvents/messages_tr.yml
@@ -212,7 +212,7 @@ creation.lacksInfoCreation: Etkinlik oluşturulamıyor, bilgi yok, alanları tek
 creation.tooManySpawns: Tüm gereken doğma noktaları zaten ayarlandı
 comun.shrink: Harita Sınırı %time% saniye içinde daralıyor
 comun.refill: Göğüs yeniden dolduruldu.
-comun.refillTime: 'Yeniden doldurma zamanı:'
+comun.refillTime: 'Sandıkların yenilenme süresi:'
 comun.shrinkTime: 'Büzülme süresi:'
 comun.warmupEnd: Isınma sonu %time% saniye
 comun.playersMove: Oyuncular %time% saniye hareket edebilecek


### PR DESCRIPTION
## Summary
- tweak Turkish translation for scoreboard refill time

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_68543f9f81108330ad6b018d2ba70aeb