### PR TITLE
Fix skywars pickups and spectator visibility

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/PickUp.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/PickUp.java
@@ -61,11 +61,13 @@ public class PickUp implements Listener {
 					plugin.getMatchActive().updateScoreboards();
 					evt.setCancelled(true);
 				}
-				break;
-			default:
-				break;
-			}
-		}
+                                break;
+                        default:
+                                break;
+                        }
+                       // allow picking up items normally in other games
+                       evt.setCancelled(false);
+               }
 
 	}
 

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -446,7 +446,7 @@ public class MatchActive {
                                         player.setGameMode(GameMode.SPECTATOR);
                                         for (Player pl : Bukkit.getOnlinePlayers()) {
                                                 if (!pl.equals(player)) {
-                                                        pl.hidePlayer(player);
+                                                        pl.hidePlayer(plugin, player);
                                                 }
                                         }
 					UtilsRandomEvents.playSound(plugin, player, XSound.ENTITY_BAT_HURT);
@@ -554,11 +554,11 @@ public class MatchActive {
 
 			}
                         for (Player p : getPlayerHandler().getPlayersVanish()) {
-                                p.showPlayer(player);
+                                p.showPlayer(plugin, player);
                         }
                         for (Player p : Bukkit.getOnlinePlayers()) {
                                 if (!p.equals(player)) {
-                                        p.showPlayer(player);
+                                        p.showPlayer(plugin, player);
                                 }
                         }
 
@@ -710,9 +710,9 @@ public class MatchActive {
 
 				UtilsDisguises.undisguisePlayer(player, plugin);
 			}
-			for (Player pla : getPlayerHandler().getPlayersVanish()) {
-				pla.showPlayer(player);
-			}
+                        for (Player pla : getPlayerHandler().getPlayersVanish()) {
+                                pla.showPlayer(plugin, player);
+                        }
 			if (playerHandler.getEnderpearlsFlying().containsKey(player)) {
 				List<Entity> pearls = playerHandler.getEnderpearlsFlying().get(player);
 				for (Entity e : pearls) {

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -3607,23 +3607,23 @@ public class UtilsRandomEvents {
 	}
 
 	public static void hidePlayers(Player player, List<Player> playersObj, RandomEvents plugin) {
-		for (Player p : playersObj) {
-			if (!p.equals(player)) {
-				player.hidePlayer(p);
+                for (Player p : playersObj) {
+                        if (!p.equals(player)) {
+                                player.hidePlayer(plugin, p);
 
-			}
-		}
+                        }
+                }
                 player.getInventory().setItemInMainHand(plugin.getReventConfig().getEndVanishItem());
 		player.updateInventory();
 		plugin.getMatchActive().getPlayerHandler().getPlayersVanish().add(player);
 	}
 
 	public static void showPlayers(Player player, List<Player> playersObj, RandomEvents plugin) {
-		for (Player p : playersObj) {
-			if (!p.equals(player)) {
-				player.showPlayer(p);
-			}
-		}
+                for (Player p : playersObj) {
+                        if (!p.equals(player)) {
+                                player.showPlayer(plugin, p);
+                        }
+                }
                 player.getInventory().setItemInMainHand(plugin.getReventConfig().getVanishItem());
 		player.updateInventory();
 		plugin.getMatchActive().getPlayerHandler().getPlayersVanish().remove(player);


### PR DESCRIPTION
## Summary
- allow item pickups in Skywars and other modes
- fix spectator visibility by passing plugin instance to hide/showPlayer

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_685456a6a66883308bc18b221bfd1842