### PR TITLE
Reduce load from cooldown checks

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -2909,7 +2909,11 @@ public class MatchActive {
 				}
 			}
 		};
-		task3.runTaskTimer(plugin, 0, 1L);
+               // Run cooldown checks less frequently to reduce CPU usage
+               // Skywars events previously updated every tick which could
+               // cause TPS drops on busy servers. Updating every 5 ticks
+               // keeps the UI responsive while lowering the load.
+               task3.runTaskTimer(plugin, 0, 5L);
 
 	}
 


### PR DESCRIPTION
## Summary
- lower frequency of the cooldown check task to mitigate TPS drop when a Skywars match starts

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68545f3c39108330a56b5125b9e287f4