### PR TITLE
Ensure players are real spectators after death

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/PickUp.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/PickUp.java
@@ -1,5 +1,6 @@
 package com.immortalman01.randomevents.listeners;
 
+import org.bukkit.GameMode;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -27,10 +28,14 @@ public class PickUp implements Listener {
                        return;
                }
                Player player = (Player) evt.getEntity();
-                if (plugin.getMatchActive() != null
-                                && plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(player)) {
-                        evt.setCancelled(true);
-                        return;
+               if (player.getGameMode() == GameMode.SPECTATOR) {
+                       evt.setCancelled(true);
+                       return;
+               }
+               if (plugin.getMatchActive() != null
+                               && plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(player)) {
+                       evt.setCancelled(true);
+                       return;
                 }
                 if (plugin.getMatchActive() != null
                                 && plugin.getMatchActive().getPlayerHandler().getPlayersObj().contains(player)) {

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -603,12 +603,14 @@ public class MatchActive {
 						UtilsRandomEvents.teleportaPlayer(player, l, plugin);
 					}
 					player.sendMessage(plugin.getLanguage().getTagPlugin() + plugin.getLanguage().getLeaveCommand());
-					if (plugin.getReventConfig().isAdvancedSpectatorMode()) {
-						player.setGameMode(GameMode.SPECTATOR);
-					}
-				}
-				player.setHealth(player.getMaxHealth());
-				player.setFoodLevel(20);
+                                        // always put eliminated players into full spectator mode
+                                        if (!getPlayerHandler().getPlayersSpectators().contains(player)) {
+                                                getPlayerHandler().getPlayersSpectators().add(player);
+                                        }
+                                        player.setGameMode(GameMode.SPECTATOR);
+                                }
+                                player.setHealth(player.getMaxHealth());
+                                player.setFoodLevel(20);
 				player.setFireTicks(0);
 			} catch (Exception e) {
 				if (player != null) {


### PR DESCRIPTION
## Summary
- keep eliminated players in spectator mode and track them as spectators
- cancel item pickups for anyone in gamemode spectator

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6854671162cc833094d9309f382d74f7