### PR TITLE
Add BetterTeams support

### DIFF
--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     compileOnly 'com.github.PlaceholderAPI:PlaceholderAPI:2.11.3'
     compileOnly 'net.citizensnpcs:citizens-main:2.0.33-SNAPSHOT'
     compileOnly 'commons-lang:commons-lang:2.6'
+    compileOnly 'com.github.booksaw:BetterTeams:4.13.2'
     compileOnly project(':stubs')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:5.11.0'

--- a/RandomEvents/plugin.yml
+++ b/RandomEvents/plugin.yml
@@ -4,7 +4,7 @@ version: 2.9.5
 api-version: 1.21
 # Removed hard dependency on Lib1711 as the required
 # functionality is now bundled directly with the plugin
-softdepend: [CrackShot, PlaceholderAPI, WorldEdit, WorldGuard, Multiworld, Multiverse-Core, NametagEdit, LibsDisguises, NoteBlockAPI, Citizens]
+softdepend: [CrackShot, PlaceholderAPI, WorldEdit, WorldGuard, Multiworld, Multiverse-Core, NametagEdit, LibsDisguises, NoteBlockAPI, Citizens, BetterTeams]
 commands:
    revent:
       description: Shows the command menu too

--- a/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
@@ -47,6 +47,7 @@ import com.immortalman01.randomevents.listeners.PickUp;
 import com.immortalman01.randomevents.listeners.Quit;
 import com.immortalman01.randomevents.listeners.Use;
 import com.immortalman01.randomevents.listeners.WeaponShoot;
+import com.immortalman01.randomevents.listeners.BetterTeamsListener;
 import com.immortalman01.randomevents.match.Kit;
 import com.immortalman01.randomevents.match.Match;
 import com.immortalman01.randomevents.match.MatchActive;
@@ -161,11 +162,17 @@ public class RandomEvents extends JavaPlugin {
 
 		}
 
-		if (getServer().getPluginManager().getPlugin("NametagEdit") != null) {
-			nametagHook = new NameTagHook(this);
-			getLoggerP().info("[RandomEvents] NameTagEdit hooked succesfully!");
+                if (getServer().getPluginManager().getPlugin("NametagEdit") != null) {
+                        nametagHook = new NameTagHook(this);
+                        getLoggerP().info("[RandomEvents] NameTagEdit hooked succesfully!");
 
-		}
+                }
+
+                if (getServer().getPluginManager().getPlugin("BetterTeams") != null) {
+                        getServer().getPluginManager().registerEvents(new BetterTeamsListener(this), this);
+                        getLoggerP().info("[RandomEvents] BetterTeams hooked succesfully!");
+
+                }
 
 		getLogger().info(" Author immortalman01- activado");
 		

--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/BetterTeamsListener.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/BetterTeamsListener.java
@@ -1,0 +1,40 @@
+package com.immortalman01.randomevents.listeners;
+
+import com.booksaw.betterTeams.Team;
+import com.immortalman01.randomevents.RandomEvents;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+public class BetterTeamsListener implements Listener {
+
+    private final RandomEvents plugin;
+
+    public BetterTeamsListener(RandomEvents plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onDamage(EntityDamageByEntityEvent event) {
+        if (plugin.getMatchActive() == null || !plugin.getMatchActive().getPlaying()) {
+            return;
+        }
+
+        if (!(event.getEntity() instanceof Player victim) || !(event.getDamager() instanceof Player attacker)) {
+            return;
+        }
+
+        Team victimTeam = Team.getTeam(victim);
+        Team attackerTeam = Team.getTeam(attacker);
+
+        if (victimTeam != null && victimTeam.equals(attackerTeam) && event.isCancelled()) {
+            Integer victimMatchTeam = plugin.getMatchActive().getEquipo(victim);
+            Integer attackerMatchTeam = plugin.getMatchActive().getEquipo(attacker);
+            if (victimMatchTeam == null || attackerMatchTeam == null || !victimMatchTeam.equals(attackerMatchTeam)) {
+                event.setCancelled(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate BetterTeams as a soft dependency
- register BetterTeams listener when the plugin is present
- allow friendly-fire during events by uncancelling BetterTeams damage checks
- include BetterTeams as a compileOnly dependency

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6854942d57c88330b0dddfe57196e98f