### PR TITLE
Fix inventory restoration after events

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -630,9 +630,9 @@ public class MatchActive {
 					&& (sacaSpectator || match.getSpectatorSpawns() == null || match.getSpectatorSpawns().isEmpty())) {
 				hazComandosDeSalir(player);
 				borraScoreboard(player);
-				if (plugin.getReventConfig().isInventoryManagement() && !getMatch().getUseOwnInventory() && res
-						&& !disconnect)
-					UtilsRandomEvents.sacaInventario(plugin, player);
+                                if (plugin.getReventConfig().isInventoryManagement() && !getMatch().getUseOwnInventory()
+                                                && !disconnect)
+                                        UtilsRandomEvents.sacaInventario(plugin, player);
 			}
 		}
 		if (plugin.getReventConfig().isShowBorders() && (getMatch().getMinigame().equals(MinigameType.SG)


### PR DESCRIPTION
## Summary
- ensure players always regain their saved items when leaving a match

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68549a4df78883309c128808db6aa5d4