### PR TITLE
Fix inventory restoration after events

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -630,9 +630,8 @@ public class MatchActive {
 					&& (sacaSpectator || match.getSpectatorSpawns() == null || match.getSpectatorSpawns().isEmpty())) {
 				hazComandosDeSalir(player);
 				borraScoreboard(player);
-                                if (plugin.getReventConfig().isInventoryManagement() && !getMatch().getUseOwnInventory()
-                                                && !disconnect)
-                                        UtilsRandomEvents.sacaInventario(plugin, player);
+                               if (plugin.getReventConfig().isInventoryManagement() && !disconnect)
+                                       UtilsRandomEvents.sacaInventario(plugin, player);
 			}
 		}
 		if (plugin.getReventConfig().isShowBorders() && (getMatch().getMinigame().equals(MinigameType.SG)

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -745,9 +745,8 @@ public class UtilsRandomEvents {
 		UtilsRandomEvents.sacaInventario(plugin, player, false);
 	}
 
-	public static void sacaInventario(RandomEvents plugin, Player player, Boolean join) {
-		if (plugin.getReventConfig().isInventoryManagement()
-				&& (plugin.getMatchActive() == null || !plugin.getMatchActive().getMatch().getUseOwnInventory())) {
+       public static void sacaInventario(RandomEvents plugin, Player player, Boolean join) {
+               if (plugin.getReventConfig().isInventoryManagement()) {
 
 			player.updateInventory();
 			File dataFolder = new File(String.valueOf(plugin.getDataFolder().getPath()) + "//inventories");


### PR DESCRIPTION
## Summary
- ensure player inventory restores regardless of `useOwnInventory` flag
- remove extra check when calling inventory restore on match exit

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6854a718ec188330b34e83e0f479f614