### PR TITLE
Fix command blocking after event end

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -60,7 +60,12 @@ public class Chat implements Listener {
                         plugin.getCmdExecutor().onCommand(event.getPlayer(), null, "randomevent",
                                         campos.toArray(new String[campos.size()]));
                 } else {
-                        boolean eventActive = plugin.getMatchActive() != null || plugin.getTournamentActive() != null;
+                        boolean matchRunning = plugin.getMatchActive() != null
+                                        && Boolean.TRUE.equals(plugin.getMatchActive().getActivated());
+                        boolean tournamentRunning = plugin.getTournamentActive() != null
+                                        && Boolean.TRUE.equals(plugin.getTournamentActive().getPlaying());
+                        boolean eventActive = matchRunning || tournamentRunning;
+
                         if (eventActive && !p.hasPermission("randomevent.bypass")) {
                                 event.setCancelled(true);
                                 p.sendMessage(plugin.getLanguage().getCmdNotAllowed());


### PR DESCRIPTION
## Summary
- ensure commands are blocked only while an event or tournament is active
- update Chat command listener logic

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6854ab08a14483308d8d163abb6d485e