### PR TITLE
Fix inventory restore for winners

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -1243,7 +1243,11 @@ public class MatchActive {
 		setCanBreak(Boolean.FALSE);
 		if (tournamentObj == null) {
 
-			for (Player p : getPlayerHandler().getPlayersSpectators()) {
+                        List<Player> specs = new ArrayList<Player>(getPlayerHandler().getPlayersSpectators());
+                        for (Player p : specs) {
+                                if (ganadores != null && ganadores.contains(p)) {
+                                        continue;
+                                }
 				try {
 					List<Entity> entities = p.getNearbyEntities(
 							plugin.getReventConfig().getDistanceClearEntities() * 1.0,


### PR DESCRIPTION
## Summary
- ensure match finalization doesn't clear winner inventory twice

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6854ac99ca3883308a25294906d3d6da