### PR TITLE
Only block commands for event participants

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -60,16 +60,22 @@ public class Chat implements Listener {
                         plugin.getCmdExecutor().onCommand(event.getPlayer(), null, "randomevent",
                                         campos.toArray(new String[campos.size()]));
                 } else {
-                        boolean matchRunning = plugin.getMatchActive() != null
-                                        && Boolean.TRUE.equals(plugin.getMatchActive().getActivated());
-                        boolean tournamentRunning = plugin.getTournamentActive() != null
-                                        && Boolean.TRUE.equals(plugin.getTournamentActive().getPlaying());
-                        boolean eventActive = matchRunning || tournamentRunning;
+                boolean matchRunning = plugin.getMatchActive() != null
+                                && Boolean.TRUE.equals(plugin.getMatchActive().getActivated());
+                boolean playerInMatch = matchRunning && (plugin.getMatchActive().getPlayerHandler().getPlayersObj().contains(p)
+                                || plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(p));
 
-                        if (eventActive && !p.hasPermission("randomevent.bypass")) {
-                                event.setCancelled(true);
-                                p.sendMessage(plugin.getLanguage().getCmdNotAllowed());
-                        }
+                boolean tournamentRunning = plugin.getTournamentActive() != null
+                                && Boolean.TRUE.equals(plugin.getTournamentActive().getPlaying());
+                boolean playerInTournament = tournamentRunning && (plugin.getTournamentActive().getPlayersObj().contains(p)
+                                || plugin.getTournamentActive().getPlayersSpectators().contains(p));
+
+                boolean playerInEvent = playerInMatch || playerInTournament;
+
+                if (playerInEvent && !p.hasPermission("randomevent.bypass")) {
+                        event.setCancelled(true);
+                        p.sendMessage(plugin.getLanguage().getCmdNotAllowed());
+                }
                 }
         }
 


### PR DESCRIPTION
## Summary
- refine command restriction logic in `Chat` listener
- only participants (players or spectators) are blocked from commands during active events

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6854b018c99483309aacd2e8a8242a4c