### PR TITLE
Fix command blocking during event warmup

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -61,7 +61,9 @@ public class Chat implements Listener {
                                         campos.toArray(new String[campos.size()]));
                 } else {
                 boolean matchRunning = plugin.getMatchActive() != null
-                                && Boolean.TRUE.equals(plugin.getMatchActive().getActivated());
+                                && (Boolean.TRUE.equals(plugin.getMatchActive().getPlaying())
+                                                || Boolean.TRUE.equals(plugin.getMatchActive().getStarting())
+                                                || Boolean.TRUE.equals(plugin.getMatchActive().getActivated()));
                 boolean playerInMatch = matchRunning && (plugin.getMatchActive().getPlayerHandler().getPlayersObj().contains(p)
                                 || plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(p));
 


### PR DESCRIPTION
## Summary
- block commands when event is starting or playing

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6854b2a037f88330875cb770f06acea7