### PR TITLE
Fix command blocking upon joining event

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -60,17 +60,13 @@ public class Chat implements Listener {
                         plugin.getCmdExecutor().onCommand(event.getPlayer(), null, "randomevent",
                                         campos.toArray(new String[campos.size()]));
                 } else {
-                boolean matchRunning = plugin.getMatchActive() != null
-                                && (Boolean.TRUE.equals(plugin.getMatchActive().getPlaying())
-                                                || Boolean.TRUE.equals(plugin.getMatchActive().getStarting())
-                                                || Boolean.TRUE.equals(plugin.getMatchActive().getActivated()));
-                boolean playerInMatch = matchRunning && (plugin.getMatchActive().getPlayerHandler().getPlayersObj().contains(p)
-                                || plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(p));
+                boolean playerInMatch = plugin.getMatchActive() != null
+                                && (plugin.getMatchActive().getPlayerHandler().getPlayersObj().contains(p)
+                                                || plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(p));
 
-                boolean tournamentRunning = plugin.getTournamentActive() != null
-                                && Boolean.TRUE.equals(plugin.getTournamentActive().getPlaying());
-                boolean playerInTournament = tournamentRunning && (plugin.getTournamentActive().getPlayersObj().contains(p)
-                                || plugin.getTournamentActive().getPlayersSpectators().contains(p));
+                boolean playerInTournament = plugin.getTournamentActive() != null
+                                && (plugin.getTournamentActive().getPlayersObj().contains(p)
+                                                || plugin.getTournamentActive().getPlayersSpectators().contains(p));
 
                 boolean playerInEvent = playerInMatch || playerInTournament;
 


### PR DESCRIPTION
## Summary
- block player commands as soon as they join a match or tournament, not only after it starts

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_685540d7f5588330846c1fac2394c4fc