### PR TITLE
Fix BetterTeams friendly-fire override

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/BetterTeamsListener.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/BetterTeamsListener.java
@@ -26,6 +26,14 @@ public class BetterTeamsListener implements Listener {
             return;
         }
 
+        if (plugin.getMatchActive().getMapHandler() != null
+                && plugin.getMatchActive().getMapHandler().getCuboid() != null) {
+            if (!plugin.getMatchActive().getMapHandler().getCuboid().contains(attacker.getLocation())
+                    || !plugin.getMatchActive().getMapHandler().getCuboid().contains(victim.getLocation())) {
+                return;
+            }
+        }
+
         Team victimTeam = Team.getTeam(victim);
         Team attackerTeam = Team.getTeam(attacker);
 


### PR DESCRIPTION
## Summary
- limit BetterTeamsListener override to the active event cuboid

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68554c4fd4bc83308ecf69f3b49372ee