### PR TITLE
Fix Spleef floor not restoring

### DIFF
--- a/RandomEvents/src/com/immortalman01/api/API1711.java
+++ b/RandomEvents/src/com/immortalman01/api/API1711.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.material.MaterialData;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.util.Vector;
 
 import com.immortalman01.util.FastBoard;
@@ -80,15 +81,17 @@ public class API1711 {
     public void convertBlock(Location loc, Object data) {
         if (loc == null || data == null) return;
         try {
-            if (data instanceof MaterialData) {
-                MaterialData md = (MaterialData) data;
-                Block b = loc.getBlock();
+            Block b = loc.getBlock();
+            if (data instanceof BlockData bd) {
+                b.setBlockData(bd, true);
+            } else if (data instanceof MaterialData md) {
                 b.setType(md.getItemType());
                 try {
                     b.setBlockData(Bukkit.createBlockData(md.getItemType()));
                 } catch (Throwable ignore) {}
             }
-        } catch (Throwable ignore) {}
+        } catch (Throwable ignore) {
+        }
     }
 
     public double getHorseSpeed(Object horse) {

--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
@@ -48,7 +48,6 @@ import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerEggThrowEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.material.MaterialData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.BlockIterator;
@@ -124,12 +123,12 @@ public class Use implements Listener {
 						&& plugin.getMatchActive().getMatch().getMinigame().equals(MinigameType.HOEHOEHOE)) {
 
 					if (plugin.getMatchActive().getMatch().getAllMaterialAllowed()
-							|| (plugin.getMatchActive().getMatch().getDatas() != null
-									&& !plugin.getMatchActive().getMatch().getDatas().isEmpty()
-									&& evt.getClickedBlock().getType() != null
-									&& evt.getClickedBlock().getState().getData() != null
-									&& UtilsRandomEvents.contieneMaterialData(evt.getClickedBlock(),
-											plugin.getMatchActive().getMatch()))) {
+                                                       || (plugin.getMatchActive().getMatch().getDatas() != null
+                                                                        && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
+                                                                        && evt.getClickedBlock().getType() != null
+                                                                        && evt.getClickedBlock().getBlockData() != null
+                                                                        && UtilsRandomEvents.contieneMaterialData(evt.getClickedBlock(),
+                                                                               plugin.getMatchActive().getMatch()))) {
 						Integer equipo = plugin.getMatchActive().getEquipoCopy(player);
 						Petos peto = Petos.getPeto(equipo);
 						if (peto != null) {
@@ -137,9 +136,9 @@ public class Use implements Listener {
 									peto.getDye())
 									|| !plugin.getMatchActive().getPlayerHandler().getPaintPlayers().contains(player)) {
 								plugin.getMatchActive().getPlayerHandler().getPaintPlayers().add(player);
-								plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(
-										evt.getClickedBlock().getLocation(),
-										evt.getClickedBlock().getState().getData().clone());
+                                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(
+                                                                               evt.getClickedBlock().getLocation(),
+                                                                               evt.getClickedBlock().getBlockData().clone());
 								evt.getClickedBlock().setType(peto.getWool().parseMaterial());
                                                                 try {
                                                                         evt.getClickedBlock().setBlockData(Bukkit.createBlockData(peto.getWool().parseMaterial()));
@@ -481,18 +480,18 @@ public class Use implements Listener {
 					if (nextBlock.getType() != null && plugin.getMatchActive().getMatch().getMaterial() != null
 							&& nextBlock.getType().toString()
 									.equals(plugin.getMatchActive().getMatch().getMaterial())) {
-						plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(nextBlock.getLocation(),
-								nextBlock.getState().getData().clone());
+                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(nextBlock.getLocation(),
+                                                               nextBlock.getBlockData().clone());
 						nextBlock.setType(XMaterial.AIR.parseMaterial());
 
 					} else if (plugin.getMatchActive().getMatch().getAllMaterialAllowed()
-							|| (plugin.getMatchActive().getMatch().getDatas() != null
-									&& !plugin.getMatchActive().getMatch().getDatas().isEmpty()
-									&& nextBlock.getType() != null && nextBlock.getState().getData() != null
-									&& UtilsRandomEvents.contieneMaterialData(nextBlock,
-											plugin.getMatchActive().getMatch()))) {
-						plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(nextBlock.getLocation(),
-								nextBlock.getState().getData().clone());
+                                                       || (plugin.getMatchActive().getMatch().getDatas() != null
+                                                                        && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
+                                                                        && nextBlock.getType() != null && nextBlock.getBlockData() != null
+                                                                        && UtilsRandomEvents.contieneMaterialData(nextBlock,
+                                                                               plugin.getMatchActive().getMatch()))) {
+                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(nextBlock.getLocation(),
+                                                               nextBlock.getBlockData().clone());
 						nextBlock.setType(XMaterial.AIR.parseMaterial());
 					}
 				}
@@ -579,11 +578,10 @@ public class Use implements Listener {
 						}
 						if (peto != null) {
 							if (addDisappear) {
-								if (!loc.getBlock().getState().getData().getItemType().toString().equals("LEGACY_AIR")
-										&& !loc.getBlock().getState().getData().getItemType().toString()
-												.equals("AIR")) {
-									plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(loc,
-											loc.getBlock().getState().getData().clone());
+                                                               if (!loc.getBlock().getType().toString().equals("LEGACY_AIR")
+                                                                               && !loc.getBlock().getType().toString().equals("AIR")) {
+                                                                        plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(loc,
+                                                                                       loc.getBlock().getBlockData().clone());
 								} else {
 									plugin.getMatchActive().getMapHandler().getBlockDisappearedType().put(loc,
 											loc.getBlock().getType());
@@ -631,13 +629,8 @@ public class Use implements Listener {
 
 							&& block.getType() != null
 							&& block.getType().toString().equals(plugin.getMatchActive().getMatch().getMaterial())) {
-						try {
-							plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(block.getLocation(),
-									new MaterialData(block.getType(), block.getData()));
-						} catch (Throwable eb) {
-							plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(block.getLocation(),
-									block.getState().getData().clone());
-						}
+                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(block.getLocation(),
+                                                               block.getBlockData().clone());
 
 						if (plugin.getMatchActive().getMatch().getMinigame().equals(MinigameType.SPLEEF)) {
 							event.blockList().remove(block);
@@ -645,18 +638,13 @@ public class Use implements Listener {
 						} else {
 						}
 					} else if (plugin.getMatchActive().getMatch().getAllMaterialAllowed()
-							|| (plugin.getMatchActive().getMatch().getDatas() != null
-									&& !plugin.getMatchActive().getMatch().getDatas().isEmpty()
-									&& block.getType() != null && block.getState().getData() != null
-									&& UtilsRandomEvents.contieneMaterialData(block,
-											plugin.getMatchActive().getMatch()))) {
-						try {
-							plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(block.getLocation(),
-									new MaterialData(block.getType(), block.getData()));
-						} catch (Throwable eb) {
-							plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(block.getLocation(),
-									block.getState().getData().clone());
-						}
+                                                       || (plugin.getMatchActive().getMatch().getDatas() != null
+                                                                        && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
+                                                                        && block.getType() != null && block.getBlockData() != null
+                                                                        && UtilsRandomEvents.contieneMaterialData(block,
+                                                                               plugin.getMatchActive().getMatch()))) {
+                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(block.getLocation(),
+                                                               block.getBlockData().clone());
 						if (plugin.getMatchActive().getMatch().getMinigame().equals(MinigameType.SPLEEF)) {
 							event.blockList().remove(block);
 						}
@@ -778,12 +766,12 @@ public class Use implements Listener {
 										.equals(plugin.getMatchActive().getMatch().getMaterial())) {
 							evt.setCancelled(true);
 							try {
-								plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(
-										evt.getBlock().getLocation(),
-										new MaterialData(evt.getBlock().getType(), evt.getBlock().getData()));
-							} catch (Throwable eb) {
-								plugin.getMatchActive().getMapHandler().getBlockDisappeared()
-										.put(evt.getBlock().getLocation(), evt.getBlock().getState().getData().clone());
+                                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(
+                                                                               evt.getBlock().getLocation(),
+                                                                               evt.getBlock().getBlockData().clone());
+                                                        } catch (Throwable eb) {
+                                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared()
+                                                                               .put(evt.getBlock().getLocation(), evt.getBlock().getBlockData().clone());
 							}
 
 							if (plugin.getMatchActive().getMatch().getMinigame().equals(MinigameType.SPLEEF)) {
@@ -797,20 +785,20 @@ public class Use implements Listener {
 								evt.getBlock().breakNaturally();
 							}
 						} else if (plugin.getMatchActive().getMatch().getAllMaterialAllowed()
-								|| (plugin.getMatchActive().getMatch().getDatas() != null
-										&& !plugin.getMatchActive().getMatch().getDatas().isEmpty()
-										&& evt.getBlock().getType() != null
-										&& evt.getBlock().getState().getData() != null
-										&& UtilsRandomEvents.contieneMaterialData(evt.getBlock(),
-												plugin.getMatchActive().getMatch()))) {
+                                                               || (plugin.getMatchActive().getMatch().getDatas() != null
+                                                                               && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
+                                                                               && evt.getBlock().getType() != null
+                                                                               && evt.getBlock().getBlockData() != null
+                                                                               && UtilsRandomEvents.contieneMaterialData(evt.getBlock(),
+                                                                               plugin.getMatchActive().getMatch()))) {
 							evt.setCancelled(true);
 							try {
-								plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(
-										evt.getBlock().getLocation(),
-										new MaterialData(evt.getBlock().getType(), evt.getBlock().getData()));
-							} catch (Throwable eb) {
-								plugin.getMatchActive().getMapHandler().getBlockDisappeared()
-										.put(evt.getBlock().getLocation(), evt.getBlock().getState().getData().clone());
+                                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(
+                                                                               evt.getBlock().getLocation(),
+                                                                               evt.getBlock().getBlockData().clone());
+                                                        } catch (Throwable eb) {
+                                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared()
+                                                                               .put(evt.getBlock().getLocation(), evt.getBlock().getBlockData().clone());
 							}
 							if (plugin.getMatchActive().getMatch().getMinigame().equals(MinigameType.SPLEEF)) {
 								evt.getBlock().setType(XMaterial.AIR.parseMaterial());
@@ -883,19 +871,19 @@ public class Use implements Listener {
 								.equals(plugin.getMatchActive().getMatch().getMaterial())) {
 					// evt.setCancelled(true);
 					evt.setCancelled(false);
-					plugin.getMatchActive().getMapHandler().getBlockPlaced().put(evt.getBlock().getLocation(),
-							evt.getBlock().getState().getData().clone());
+                                        plugin.getMatchActive().getMapHandler().getBlockPlaced().put(evt.getBlock().getLocation(),
+                                                        evt.getBlock().getBlockData().clone());
 					// evt.getBlock().setType(XMaterial.AIR.parseMaterial());
 				} else if (plugin.getMatchActive().getMatch().getAllMaterialAllowed()
-						|| (plugin.getMatchActive().getMatch().getDatas() != null
-								&& !plugin.getMatchActive().getMatch().getDatas().isEmpty()
-								&& evt.getBlock().getType() != null && evt.getBlock().getState().getData() != null
-								&& UtilsRandomEvents.contieneMaterialData(evt.getBlock(),
-										plugin.getMatchActive().getMatch()))) {
+                                                || (plugin.getMatchActive().getMatch().getDatas() != null
+                                                                && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
+                                                                && evt.getBlock().getType() != null && evt.getBlock().getBlockData() != null
+                                                                && UtilsRandomEvents.contieneMaterialData(evt.getBlock(),
+                                                                               plugin.getMatchActive().getMatch()))) {
 					// evt.setCancelled(true);
 					evt.setCancelled(false);
-					plugin.getMatchActive().getMapHandler().getBlockPlaced().put(evt.getBlock().getLocation(),
-							evt.getBlock().getState().getData().clone());
+                                        plugin.getMatchActive().getMapHandler().getBlockPlaced().put(evt.getBlock().getLocation(),
+                                                        evt.getBlock().getBlockData().clone());
 					// evt.getBlock().setType(XMaterial.AIR.parseMaterial());
 				} else {
 					evt.setCancelled(true);
@@ -923,8 +911,8 @@ public class Use implements Listener {
 
 				// evt.setCancelled(true);
 				evt.setCancelled(false);
-				plugin.getMatchActive().getMapHandler().getBlockPlaced().put(l.getBlock().getLocation(),
-						l.getBlock().getState().getData().clone());
+                                plugin.getMatchActive().getMapHandler().getBlockPlaced().put(l.getBlock().getLocation(),
+                                                l.getBlock().getBlockData().clone());
 				// evt.getBlock().setType(XMaterial.AIR.parseMaterial());
 
 			}
@@ -940,8 +928,8 @@ public class Use implements Listener {
 
 			// evt.setCancelled(true);
 			// evt.setCancelled(false);
-			plugin.getMatchActive().getMapHandler().getBlockPlaced().put(evt.getBlock().getLocation(),
-					evt.getBlock().getState().getData().clone());
+                        plugin.getMatchActive().getMapHandler().getBlockPlaced().put(evt.getBlock().getLocation(),
+                                        evt.getBlock().getBlockData().clone());
 			// evt.getBlock().setType(XMaterial.AIR.parseMaterial());
 
 		}
@@ -982,8 +970,8 @@ public class Use implements Listener {
 							if (plugin.getMatchActive().getMatch().getAllMaterialAllowed()
 									|| (plugin.getMatchActive().getMatch().getDatas() != null
 											&& !plugin.getMatchActive().getMatch().getDatas().isEmpty()
-											&& l2.getBlock().getType() != null
-											&& l2.getBlock().getState().getData() != null
+                                                               && l2.getBlock().getType() != null
+                                                               && l2.getBlock().getBlockData() != null
 											&& (UtilsRandomEvents.contieneMaterialData(l2.getBlock(),
 													plugin.getMatchActive().getMatch())
 													|| l2.getBlock().getType().equals(XMaterial.ANVIL.parseMaterial())
@@ -991,8 +979,8 @@ public class Use implements Listener {
 															.equals(XMaterial.CHIPPED_ANVIL.parseMaterial())
 													|| l2.getBlock().getType()
 															.equals(XMaterial.DAMAGED_ANVIL.parseMaterial())))) {
-								plugin.getMatchActive().getMapHandler().getBlockDisappeared()
-										.put(l2.getBlock().getLocation(), l2.getBlock().getState().getData().clone());
+                                                               plugin.getMatchActive().getMapHandler().getBlockDisappeared()
+                                                                               .put(l2.getBlock().getLocation(), l2.getBlock().getBlockData().clone());
 								l2.getBlock().setType(XMaterial.AIR.parseMaterial());
 
 							}

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -37,7 +37,7 @@ import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.MaterialData;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -1435,9 +1435,9 @@ public class MatchActive {
 			break;
 		}
 
-		for (Entry<Location, MaterialData> entrada : getMapHandler().getBlockDisappeared().entrySet()) {
-			plugin.getApi().convertBlock(entrada.getKey(), entrada.getValue());
-		}
+               for (Entry<Location, BlockData> entrada : getMapHandler().getBlockDisappeared().entrySet()) {
+                       plugin.getApi().convertBlock(entrada.getKey(), entrada.getValue());
+               }
 
 		for (Entry<Location, Material> entrada : getMapHandler().getBlockDisappearedType().entrySet()) {
 			entrada.getKey().getBlock().setType(entrada.getValue());
@@ -2563,13 +2563,8 @@ public class MatchActive {
 		for (List<Location> loc : glasses.values()) {
 			Location correcto = loc.get(plugin.getRandom().nextInt(loc.size()));
 			for (Location l : loc) {
-				try {
-					getMapHandler().getBlockDisappeared().put(l.getBlock().getLocation(),
-							new MaterialData(l.getBlock().getType(), l.getBlock().getData()));
-				} catch (Throwable eb) {
-					getMapHandler().getBlockDisappeared().put(l.getBlock().getLocation(),
-							l.getBlock().getState().getData().clone());
-				}
+                               getMapHandler().getBlockDisappeared().put(l.getBlock().getLocation(),
+                                               l.getBlock().getBlockData().clone());
 				l.getBlock().setType(XMaterial.GLASS.parseMaterial());
 				if (plugin.getReventConfig().isBiggerPlatform()) {
 					List<Location> listaPlataformas = new ArrayList<>();
@@ -2582,18 +2577,18 @@ public class MatchActive {
 					Block south = l.getBlock().getRelative(BlockFace.SOUTH, 1);
 					Block southWest = l.getBlock().getRelative(BlockFace.SOUTH_WEST, 1);
 
-					getMapHandler().getBlockPlaced().put(east.getLocation(), east.getState().getData().clone());
-					getMapHandler().getBlockPlaced().put(northEast.getLocation(),
-							northEast.getState().getData().clone());
-					getMapHandler().getBlockPlaced().put(southEast.getLocation(),
-							southEast.getState().getData().clone());
-					getMapHandler().getBlockPlaced().put(north.getLocation(), north.getState().getData().clone());
-					getMapHandler().getBlockPlaced().put(west.getLocation(), west.getState().getData().clone());
-					getMapHandler().getBlockPlaced().put(northWest.getLocation(),
-							northWest.getState().getData().clone());
-					getMapHandler().getBlockPlaced().put(south.getLocation(), south.getState().getData().clone());
-					getMapHandler().getBlockPlaced().put(southWest.getLocation(),
-							southWest.getState().getData().clone());
+                                       getMapHandler().getBlockPlaced().put(east.getLocation(), east.getBlockData().clone());
+                                       getMapHandler().getBlockPlaced().put(northEast.getLocation(),
+                                                       northEast.getBlockData().clone());
+                                       getMapHandler().getBlockPlaced().put(southEast.getLocation(),
+                                                       southEast.getBlockData().clone());
+                                       getMapHandler().getBlockPlaced().put(north.getLocation(), north.getBlockData().clone());
+                                       getMapHandler().getBlockPlaced().put(west.getLocation(), west.getBlockData().clone());
+                                       getMapHandler().getBlockPlaced().put(northWest.getLocation(),
+                                                       northWest.getBlockData().clone());
+                                       getMapHandler().getBlockPlaced().put(south.getLocation(), south.getBlockData().clone());
+                                       getMapHandler().getBlockPlaced().put(southWest.getLocation(),
+                                                       southWest.getBlockData().clone());
 
 					east.setType(XMaterial.GLASS.parseMaterial());
 					northEast.setType(XMaterial.GLASS.parseMaterial());
@@ -2644,13 +2639,8 @@ public class MatchActive {
 		getMapHandler().setBlockPartyBlocks(
 				UtilsRandomEvents.getBlocksLocation(getMatch().getLocation1(), getMatch().getLocation2(), plugin));
 		for (Location l : getMapHandler().getBlockPartyBlocks()) {
-			try {
-				getMapHandler().getBlockDisappeared().put(l.getBlock().getLocation(),
-						new MaterialData(l.getBlock().getType(), l.getBlock().getData()));
-			} catch (Throwable eb) {
-				getMapHandler().getBlockDisappeared().put(l.getBlock().getLocation(),
-						l.getBlock().getState().getData().clone());
-			}
+                       getMapHandler().getBlockDisappeared().put(l.getBlock().getLocation(),
+                                       l.getBlock().getBlockData().clone());
 		}
 		task = new BukkitRunnable() {
 			public void run() {

--- a/RandomEvents/src/com/immortalman01/randomevents/match/data/MatchMapDataHandler.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/data/MatchMapDataHandler.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Fireball;
-import org.bukkit.material.MaterialData;
+import org.bukkit.block.data.BlockData;
 
 import com.immortalman01.randomevents.match.utils.Cuboid;
 
@@ -26,11 +26,11 @@ public class MatchMapDataHandler {
 
 	private Map<Location, Long> blockDisappear;
 
-	private Map<Location, MaterialData> blockDisappeared;
+       private Map<Location, BlockData> blockDisappeared;
 
-	private Map<Location, Material> blockDisappearedType;
+       private Map<Location, Material> blockDisappearedType;
 
-	private Map<Location, MaterialData> blockPlaced;
+       private Map<Location, BlockData> blockPlaced;
 
 	private Set<Fireball> fireballs;
 
@@ -42,10 +42,10 @@ public class MatchMapDataHandler {
 
 	public MatchMapDataHandler() {
 		super();
-		this.blockDisappear = new HashMap<Location, Long>();
-		this.blockDisappeared = new HashMap<Location, MaterialData>();
-		this.blockDisappearedType = new HashMap<Location, Material>();
-		this.blockPlaced = new HashMap<Location, MaterialData>();
+               this.blockDisappear = new HashMap<Location, Long>();
+               this.blockDisappeared = new HashMap<Location, BlockData>();
+               this.blockDisappearedType = new HashMap<Location, Material>();
+               this.blockPlaced = new HashMap<Location, BlockData>();
 		this.checkpoints = new HashMap<String, Location>();
 		this.chests = new ArrayList<Location>();
 		this.fireballs = new HashSet<Fireball>();
@@ -119,13 +119,13 @@ public class MatchMapDataHandler {
 		this.blockDisappear = blockDisappear;
 	}
 
-	public Map<Location, MaterialData> getBlockDisappeared() {
-		return blockDisappeared;
-	}
+       public Map<Location, BlockData> getBlockDisappeared() {
+               return blockDisappeared;
+       }
 
-	public void setBlockDisappeared(Map<Location, MaterialData> blockDisappeared) {
-		this.blockDisappeared = blockDisappeared;
-	}
+       public void setBlockDisappeared(Map<Location, BlockData> blockDisappeared) {
+               this.blockDisappeared = blockDisappeared;
+       }
 
 	public Map<Location, Material> getBlockDisappearedType() {
 		return blockDisappearedType;
@@ -135,13 +135,13 @@ public class MatchMapDataHandler {
 		this.blockDisappearedType = blockDisappearedType;
 	}
 
-	public Map<Location, MaterialData> getBlockPlaced() {
-		return blockPlaced;
-	}
+       public Map<Location, BlockData> getBlockPlaced() {
+               return blockPlaced;
+       }
 
-	public void setBlockPlaced(Map<Location, MaterialData> blockPlaced) {
-		this.blockPlaced = blockPlaced;
-	}
+       public void setBlockPlaced(Map<Location, BlockData> blockPlaced) {
+               this.blockPlaced = blockPlaced;
+       }
 
 	public void setBlockPartyBlocks(List<Location> blocksLocation) {
 		this.blockPartyBlocks = new ArrayList<Location>(blocksLocation);

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -1711,8 +1711,8 @@ public class UtilsRandomEvents {
 			}
 		}
 		for (Location l : blocksToDisappear) {
-			matchActive.getMapHandler().getBlockDisappear().remove(l);
-			matchActive.getMapHandler().getBlockDisappeared().put(l, l.getBlock().getState().getData());
+                       matchActive.getMapHandler().getBlockDisappear().remove(l);
+                       matchActive.getMapHandler().getBlockDisappeared().put(l, l.getBlock().getBlockData().clone());
 			l.getBlock().setType(XMaterial.AIR.parseMaterial());
 
 		}
@@ -1846,16 +1846,14 @@ public class UtilsRandomEvents {
 		return tamanyo;
 	}
 
-	public static boolean contieneMaterialData(Block block, Match match) {
-                for (MaterialData data : match.getDatas()) {
-                        Material mat = block.getType();
-                        byte blockData = block.getState().getData().getData();
-                        if (data.getItemType() == mat && data.getData() == blockData) {
-                                return true;
-                        }
-                }
-                return false;
-        }
+       public static boolean contieneMaterialData(Block block, Match match) {
+               for (MaterialData data : match.getDatas()) {
+                       if (data.getItemType() == block.getType()) {
+                               return true;
+                       }
+               }
+               return false;
+       }
 
 	public static BannedPlayers cargarBannedPlayers(RandomEvents plugin) {
 


### PR DESCRIPTION
## Summary
- store block states using `BlockData` instead of deprecated `MaterialData`
- restore blocks with the full `BlockData`
- adjust event listeners to capture `BlockData` when blocks are broken or placed
- update utility checks for block material

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6855c4df45ac833091b5a47cb0478913