### PR TITLE
Fix Spleef block handling and arena reset

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -1512,13 +1512,13 @@ public class Chat implements Listener {
 						if (message.equalsIgnoreCase(Constantes.DONE)) {
 							if (player.getInventory().getItemInMainHand() != null
 									&& player.getInventory().getItemInMainHand().getType() != (XMaterial.AIR.parseMaterial())) {
-								try {
-									MaterialData mat = new MaterialData(player.getInventory().getItemInMainHand().getType(),
-											player.getInventory().getItemInMainHand().getData().getData());
-									match.getDatas().add(mat);
-								} catch (Throwable eb) {
-									match.getDatas().add(player.getInventory().getItemInMainHand().getData());
-								}
+                                                                try {
+                                                                        MaterialData mat = new MaterialData(player.getInventory().getItemInMainHand().getType(),
+                                                                                player.getInventory().getItemInMainHand().getData().getData());
+                                                                        match.getDatas().add(mat);
+                                                                } catch (Throwable eb) {
+                                                                        match.getDatas().add(player.getInventory().getItemInMainHand().getData());
+                                                                }
 								plugin.getPlayersCreation().remove(player.getName());
 
 							} else {
@@ -1539,6 +1539,7 @@ public class Chat implements Listener {
 								} catch (Throwable eb) {
 									match.getDatas().add(player.getInventory().getItemInMainHand().getData());
 								}
+                                                                match.setMaterial(player.getInventory().getItemInMainHand().getType().toString());
 								plugin.getPlayersCreation().remove(player.getName());
 								plugin.getPlayersCreation().put(player.getName(),
 										Creacion.ANOTHER_MATERIAL_SPLEEF.getPosition());

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -1435,13 +1435,21 @@ public class MatchActive {
 			break;
 		}
 
-		for (Entry<Location, MaterialData> entrada : getMapHandler().getBlockDisappeared().entrySet()) {
-			plugin.getApi().convertBlock(entrada.getKey(), entrada.getValue());
-		}
+                for (Entry<Location, MaterialData> entrada : getMapHandler().getBlockDisappeared().entrySet()) {
+                        plugin.getApi().convertBlock(entrada.getKey(), entrada.getValue());
+                }
 
-		for (Entry<Location, Material> entrada : getMapHandler().getBlockDisappearedType().entrySet()) {
-			entrada.getKey().getBlock().setType(entrada.getValue());
-		}
+                for (Entry<Location, Material> entrada : getMapHandler().getBlockDisappearedType().entrySet()) {
+                        entrada.getKey().getBlock().setType(entrada.getValue());
+                }
+
+                for (Entry<Location, MaterialData> entrada : getMapHandler().getBlockPlaced().entrySet()) {
+                        plugin.getApi().convertBlock(entrada.getKey(), entrada.getValue());
+                }
+
+                getMapHandler().getBlockDisappeared().clear();
+                getMapHandler().getBlockDisappearedType().clear();
+                getMapHandler().getBlockPlaced().clear();
 
 		hazComandosDeFin();
 		for (Entity ent : getMobs()) {
@@ -1473,9 +1481,6 @@ public class MatchActive {
 		this.getPlayerHandler().getPlayersSpectators().clear();
 		this.activated = Boolean.FALSE;
 
-		for (Location l : getMapHandler().getBlockPlaced().keySet()) {
-			l.getBlock().setType(XMaterial.AIR.parseMaterial());
-		}
 
 		setPlaying(Boolean.FALSE);
 		if (tournamentObj == null && reinicia)


### PR DESCRIPTION
## Summary
- register the chosen Spleef block during creation
- restore placed blocks and clear recorded changes on match end

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6855dcc097088330839497b4c2c0500e