### PR TITLE
Improve Spleef block tracking

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
@@ -769,9 +769,15 @@ public class Use implements Listener {
 							evt.setCancelled(false);
 							plugin.getMatchActive().getMapHandler().getBlockPlaced()
 									.remove(evt.getBlock().getLocation());
-                                                } else if (plugin.getMatchActive().getMatch().getMaterial() != null
+                                                } else if ((plugin.getMatchActive().getMatch().getMaterial() != null
 
-                                                                && evt.getBlock().getType() != null && evt.getBlock().getType().equals(org.bukkit.Material.matchMaterial(plugin.getMatchActive().getMatch().getMaterial()))) {
+                                                                && evt.getBlock().getType() != null && evt.getBlock().getType().equals(org.bukkit.Material.matchMaterial(plugin.getMatchActive().getMatch().getMaterial())))
+
+                                                                || (plugin.getMatchActive().getMatch().getMinigame().equals(MinigameType.SPLEEF)
+                                                                                && plugin.getMatchActive().getMatch().getDatas() != null
+                                                                                && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
+                                                                                && evt.getBlock().getType() != null
+                                                                                && UtilsRandomEvents.contieneMaterialData(evt.getBlock(), plugin.getMatchActive().getMatch()))) {
 							evt.setCancelled(true);
                                                        plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(
                                                                        evt.getBlock().getLocation(),

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/UseMineEventTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/UseMineEventTest.java
@@ -104,4 +104,20 @@ public class UseMineEventTest {
         verify(block).breakNaturally();
         assertEquals(1, disappeared.size());
     }
+
+    @Test
+    public void spleefAllowsBlockFromDatas() {
+        when(match.getMinigame()).thenReturn(MinigameType.SPLEEF);
+        when(match.getMaterial()).thenReturn("SNOW_BLOCK");
+        when(match.getAllMaterialAllowed()).thenReturn(false);
+        List<MaterialData> datas = new ArrayList<>();
+        datas.add(new MaterialData(Material.DIRT));
+        when(match.getDatas()).thenReturn(datas);
+
+        use.onMine(event);
+
+        verify(event).setCancelled(true);
+        verify(block, never()).breakNaturally();
+        assertEquals(1, disappeared.size());
+    }
 }


### PR DESCRIPTION
## Summary
- fix material checks so Spleef accepts any configured block
- add regression test for extra Spleef block

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_685692acccbc83309782c6a861e61c6b