### PR TITLE
Fix Spleef block restoration

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
@@ -745,8 +745,9 @@ public class Use implements Listener {
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onMine(BlockBreakEvent evt) {
 		Player player = evt.getPlayer();
-		if (plugin.getMatchActive() != null
-				&& plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(player)) {
+                if (plugin.getMatchActive() != null
+                                && (plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(player)
+                                                || plugin.getMatchActive().getPlayerHandler().getPlayers().contains(player.getName()))) {
 			if (!plugin.getMatchActive().getCanBreak()) {
 				evt.setCancelled(true);
 			} else {
@@ -828,9 +829,10 @@ public class Use implements Listener {
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onFill(PlayerBucketFillEvent evt) {
 		Player player = evt.getPlayer();
-		if (plugin.getMatchActive() != null
-				&& plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(player)
-				&& plugin.getMatchActive().getPlaying()) {
+                if (plugin.getMatchActive() != null
+                                && (plugin.getMatchActive().getPlayerHandler().getPlayersSpectators().contains(player)
+                                                || plugin.getMatchActive().getPlayerHandler().getPlayers().contains(player.getName()))
+                                && plugin.getMatchActive().getPlaying()) {
 			if (plugin.getMatchActive().getMatch().getMinigame().equals(MinigameType.ANVIL_SPLEEF)
 					|| plugin.getMatchActive().getMatch().getMinigame().equals(MinigameType.SPLATOON)
 					|| plugin.getMatchActive().getMatch().getMinigame().equals(MinigameType.HOEHOEHOE)

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/UseMineEventTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/UseMineEventTest.java
@@ -120,4 +120,24 @@ public class UseMineEventTest {
         verify(block, never()).breakNaturally();
         assertEquals(1, disappeared.size());
     }
+
+    @Test
+    public void playerListAllowsMining() {
+        when(match.getMinigame()).thenReturn(MinigameType.SPLEGG);
+        when(match.getMaterial()).thenReturn("SNOW_BLOCK");
+        when(match.getAllMaterialAllowed()).thenReturn(true);
+
+        // player not in spectators but in players list
+        when(handler.getPlayersSpectators()).thenReturn(Collections.emptyList());
+        List<String> players = new ArrayList<>();
+        players.add("name");
+        when(player.getName()).thenReturn("name");
+        when(handler.getPlayers()).thenReturn(players);
+
+        use.onMine(event);
+
+        verify(event).setCancelled(true);
+        verify(block).breakNaturally();
+        assertEquals(1, disappeared.size());
+    }
 }


### PR DESCRIPTION
## Summary
- track mined blocks if the player is an active participant or spectator
- update bucket fill handler with the same logic
- test that players in the active list still record blocks

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68569728c0bc8330be9c658193ce5568