### PR TITLE
Fix color meta deserialization

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/json/GsonFactory.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/json/GsonFactory.java
@@ -152,6 +152,22 @@ public class GsonFactory {
         }
         return map;
     }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> recursiveRemoveClassKey(Map<String, Object> originalMap) {
+        Map<String, Object> map = new HashMap<String, Object>();
+        for (Entry<String, Object> entry : originalMap.entrySet()) {
+            if (CLASS_KEY.equals(entry.getKey())) {
+                continue;
+            }
+            Object value = entry.getValue();
+            if (value instanceof Map) {
+                value = recursiveRemoveClassKey((Map<String, Object>) value);
+            }
+            map.put(entry.getKey(), value);
+        }
+        return map;
+    }
  
     private static class ExposeExlusion implements ExclusionStrategy {
         @Override
@@ -270,7 +286,7 @@ public class GsonFactory {
         }
  
         private ItemStack fromRaw (String raw) {
-            Map<String, Object> keys = g.fromJson(raw, seriType);
+                Map<String, Object> keys = g.fromJson(raw, seriType);
  
             if(keys.get("amount") != null) {
                 Double d = (Double) keys.get("amount");
@@ -387,12 +403,13 @@ public class GsonFactory {
     		if(item == null)
     			return null;
 
-    		if(keys.containsKey("meta")) {
-    			Map<String, Object> itemmeta = (Map<String, Object>) keys.get("meta");
-    			itemmeta = recursiveDoubleToInteger(itemmeta);
-    			ItemMeta meta = (ItemMeta) ConfigurationSerialization.deserializeObject(itemmeta, ConfigurationSerialization.getClassByAlias("ItemMeta"));
-    			item.setItemMeta(meta);
-    		}
+                if(keys.containsKey("meta")) {
+                        Map<String, Object> itemmeta = (Map<String, Object>) keys.get("meta");
+                        itemmeta = recursiveDoubleToInteger(itemmeta);
+                        itemmeta = recursiveRemoveClassKey(itemmeta);
+                        ItemMeta meta = (ItemMeta) ConfigurationSerialization.deserializeObject(itemmeta, ConfigurationSerialization.getClassByAlias("ItemMeta"));
+                        item.setItemMeta(meta);
+                }
 
     		return item;
     	}

--- a/RandomEvents/src/com/immortalman01/randomevents/json/JsonSerializerDeserializer.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/json/JsonSerializerDeserializer.java
@@ -182,6 +182,7 @@ public class JsonSerializerDeserializer<T> {
             if(keys.containsKey("meta")) {
                 Map<String, Object> itemmeta = (Map<String, Object>) keys.get("meta");
                 itemmeta = recursiveDoubleToInteger(itemmeta);
+                itemmeta = recursiveRemoveClassKey(itemmeta);
                 ItemMeta meta = (ItemMeta) ConfigurationSerialization.deserializeObject(itemmeta, ConfigurationSerialization.getClassByAlias("ItemMeta"));
                 item.setItemMeta(meta);
             }
@@ -202,6 +203,22 @@ public class JsonSerializerDeserializer<T> {
                 }else{
                     map.put(entry.getKey(), o);
                 }
+            }
+            return map;
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, Object> recursiveRemoveClassKey(Map<String, Object> originalMap) {
+            Map<String, Object> map = new HashMap<String, Object>();
+            for (Entry<String, Object> entry : originalMap.entrySet()) {
+                if (CLASS_KEY.equals(entry.getKey())) {
+                    continue;
+                }
+                Object value = entry.getValue();
+                if (value instanceof Map) {
+                    value = recursiveRemoveClassKey((Map<String, Object>) value);
+                }
+                map.put(entry.getKey(), value);
             }
             return map;
         }


### PR DESCRIPTION
## Summary
- strip class key info from item meta maps before deserialization
- ensure Gson adapters remove these keys recursively

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6856a98ca2d4833089dbc26f7b124457