### PR TITLE
Fix snowball duplication in Spleef

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
@@ -414,11 +414,13 @@ public class Use implements Listener {
 				Snowball snowball = (Snowball) evt.getEntity();
 				if (snowball.getShooter() != null && snowball.getShooter() instanceof Player) {
 					Player p = (Player) snowball.getShooter();
-					if (plugin.getMatchActive().getPlayerHandler().getPlayers().contains(p.getName())) {
-						if (plugin.getReventConfig().isInfiniteSnowballs()) {
-							p.getInventory().addItem(XMaterial.SNOWBALL.parseItem());
-						}
-					}
+                                        if (plugin.getMatchActive().getPlayerHandler().getPlayers().contains(p.getName())) {
+                                                if (plugin.getReventConfig().isInfiniteSnowballs()
+                                                                && !plugin.getMatchActive().getMatch().getMinigame()
+                                                                                .equals(MinigameType.SPLEEF)) {
+                                                        p.getInventory().addItem(XMaterial.SNOWBALL.parseItem());
+                                                }
+                                        }
 				}
 			} else if (evt.getEntity() instanceof EnderPearl) {
 				EnderPearl ep = (EnderPearl) evt.getEntity();


### PR DESCRIPTION
## Summary
- avoid giving players new snowballs when throwing them in Spleef

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6856cb586a748330b6d7f259f2808bd3