### PR TITLE
Fix event list sorting when creating new events

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -209,12 +209,13 @@ public class UtilsRandomEvents {
 					}
 
 				}
-				if (matchAux == null) {
-					plugin.getMatches().add(match);
-				} else {
-					plugin.getMatches().set(plugin.getMatches().indexOf(matchAux), match);
-				}
-				if (player != null) {
+                                if (matchAux == null) {
+                                        plugin.getMatches().add(match);
+                                } else {
+                                        plugin.getMatches().set(plugin.getMatches().indexOf(matchAux), match);
+                                }
+                                Collections.sort(plugin.getMatches());
+                                if (player != null) {
 
 					player.sendMessage(
 							plugin.getLanguage().getTagPlugin() + plugin.getLanguage().getEndOfArenaCreation());


### PR DESCRIPTION
## Summary
- ensure events remain sorted by minigame type after creating new events

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6856eaf35ad08330bd8029b7e266059d