### PR TITLE
Fix team GUI slot assignment

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -393,7 +393,15 @@ public class GUI implements Listener {
 
 						Integer equipoActual = plugin.getMatchActive().getEquipo(p);
 
-						Integer pos = event.getInventory().first(item);
+                                                // Using Inventory#first causes the
+                                                // index of the first matching item to
+                                                // be returned which means every click
+                                                // assigns the player to the first team
+                                                // when multiple identical items are
+                                                // present. Use the actual clicked slot
+                                                // instead so players join the team they
+                                                // selected.
+                                                Integer pos = event.getRawSlot();
 
 						if (pos < plugin.getMatchActive().getMatch().getNumberOfTeams()) {
 							if (equipoActual != null) {


### PR DESCRIPTION
## Summary
- fix team GUI item click by using raw slot instead of Inventory#first

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6856f9fa316c833088c11ae05068e8a8