### PR TITLE
Fix scoreboard after selecting team

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -422,7 +422,8 @@ public class GUI implements Listener {
 
 							p.closeInventory();
 							UtilsRandomEvents.playSound(plugin,p, XSound.ENTITY_PLAYER_LEVELUP);
-							plugin.getMatchActive().updateTeamItem(p);
+                                                        plugin.getMatchActive().updateTeamItem(p);
+                                                        plugin.getMatchActive().updateScoreboards();
 
 						}
 					}


### PR DESCRIPTION
## Summary
- refresh scoreboards after changing team

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_685712f09ed08330873a88fe346c5d8f