### PR TITLE
Fix GUI team slot detection

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -401,7 +401,17 @@ public class GUI implements Listener {
                                                 // present. Use the actual clicked slot
                                                 // instead so players join the team they
                                                 // selected.
-                                                Integer pos = event.getRawSlot();
+                                                // Use the slot index relative to the
+                                                // clicked inventory rather than the
+                                                // absolute raw slot. Some server
+                                                // implementations return the raw slot
+                                                // index of the entire view which may
+                                                // cause players to be assigned to the
+                                                // wrong team when clicking their own
+                                                // inventory. getSlot() reliably
+                                                // represents the clicked slot inside
+                                                // the GUI.
+                                                Integer pos = event.getSlot();
 
 						if (pos < plugin.getMatchActive().getMatch().getNumberOfTeams()) {
 							if (equipoActual != null) {


### PR DESCRIPTION
## Summary
- handle team selection slot via `event.getSlot()` so players join the team they click

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68571ad85e50833092c98e87c8d25173