### PR TITLE
Fix Paintball team gear update

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -433,7 +433,6 @@ public class GUI implements Listener {
                                                         p.closeInventory();
                                                         UtilsRandomEvents.playSound(plugin,p, XSound.ENTITY_PLAYER_LEVELUP);
                                                         plugin.getMatchActive().applyTeamSelection(p);
-                                                        plugin.getMatchActive().updateTeamItem(p);
                                                         plugin.getMatchActive().updateScoreboards();
 
 						}

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -3673,12 +3673,27 @@ public class MatchActive {
 
        /**
         * Update nametag/scoreboard team after a player selects a team.
-        * This keeps name colors and team messages in sync with the choice made
-        * in the GUI.
+        * This keeps name colors, equipment and team messages in sync with the
+        * choice made in the GUI.
         */
        public void applyTeamSelection(Player p) {
                crearTeam(p);
+               updateTeamChestplate(p);
+               updateTeamItem(p);
                mandaMensajesEquipo(getPlayerHandler().getEquipos());
+       }
+
+       /**
+        * Give the player the coloured chestplate for their current team.
+        */
+       public void updateTeamChestplate(Player p) {
+               if (plugin.getReventConfig().isUseTeamChestplate()) {
+                       Petos peto = Petos.getPeto(getEquipo(p));
+                       if (peto != null) {
+                               p.getInventory().setChestplate(peto.getPeto());
+                               p.updateInventory();
+                       }
+               }
        }
 
         public void iniciaPlayerBeast(Player p) {


### PR DESCRIPTION
## Summary
- ensure selecting a team updates chestplate and team item
- update team selection GUI handler accordingly

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_685720efc5908330bf31ab0d19ac08fb