### PR TITLE
Fix scoreboard teams for long names

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -1349,17 +1349,19 @@ public class MatchActive {
 	}
 
 	public void unregisterTeam(Player p) {
-		if (teams) {
-			if (plugin.getNametagHook() == null) {
-				if (plugin.getColorBoard().getTeam(p.getName()) != null) {
-					plugin.getColorBoard().getTeam(p.getName()).unregister();
-				}
-			} else {
-				// getPlayerHandler().getPlayersPrefix().put(p,
-				// plugin.getNametagHook().getApi().getNametag(p).getPrefix());
-				plugin.getNametagHook().getApi().setPrefix(p, getPlayerHandler().getPlayersPrefix().get(p.getName()));
+               if (teams) {
+                       if (plugin.getNametagHook() == null) {
+                               String id = getPlayerHandler().getScoreboardTeamIds().getOrDefault(p.getName(), p.getName());
+                               if (plugin.getColorBoard().getTeam(id) != null) {
+                                       plugin.getColorBoard().getTeam(id).unregister();
+                               }
+                               getPlayerHandler().getScoreboardTeamIds().remove(p.getName());
+                       } else {
+                               // getPlayerHandler().getPlayersPrefix().put(p,
+                               // plugin.getNametagHook().getApi().getNametag(p).getPrefix());
+                               plugin.getNametagHook().getApi().setPrefix(p, getPlayerHandler().getPlayersPrefix().get(p.getName()));
 
-			}
+                       }
 		}
 	}
 
@@ -3654,11 +3656,24 @@ public class MatchActive {
        private void crearTeam(Player p) {
                teams = Boolean.TRUE;
                if (plugin.getNametagHook() == null) {
-                       if (plugin.getColorBoard().getTeam(p.getName()) != null) {
-                               plugin.getColorBoard().getTeam(p.getName()).unregister();
+                       // Scoreboard team names are limited to 16 characters. Use a
+                       // shorter identifier when the player name exceeds this limit.
+                       String teamId = p.getName();
+                       if (teamId.length() > 16) {
+                               teamId = teamId.substring(0, Math.min(12, teamId.length()))
+                                               + Integer.toHexString(random.nextInt(0x1000));
+                               if (teamId.length() > 16) {
+                                       teamId = teamId.substring(0, 16);
+                               }
                        }
 
-                       Team t = plugin.getColorBoard().registerNewTeam(p.getName());
+                       String oldId = getPlayerHandler().getScoreboardTeamIds().getOrDefault(p.getName(), teamId);
+                       if (plugin.getColorBoard().getTeam(oldId) != null) {
+                               plugin.getColorBoard().getTeam(oldId).unregister();
+                       }
+
+                       Team t = plugin.getColorBoard().registerNewTeam(teamId);
+                       getPlayerHandler().getScoreboardTeamIds().put(p.getName(), teamId);
 
                        t.setPrefix(Petos.getPeto(getEquipo(p)).getChatColor() + "");
                        t.addEntry(p.getName());

--- a/RandomEvents/src/com/immortalman01/randomevents/match/data/MatchPlayerHandler.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/data/MatchPlayerHandler.java
@@ -44,7 +44,12 @@ public class MatchPlayerHandler {
 
 	private Map<Player, Long> playersContadores;
 
-	private Map<String, String> playersPrefix;
+        private Map<String, String> playersPrefix;
+       /**
+        * Map from player name to the identifier used when creating their
+        * scoreboard team. Bukkit restricts team names to 16 characters.
+        */
+       private Map<String, String> scoreboardTeamIds;
 
 	private Map<String, FastBoard> scoreboards;
 	private Map<String, Scoreboard> oldScoreboards;
@@ -67,7 +72,8 @@ public class MatchPlayerHandler {
 		this.playersInvincible = new HashMap<String, Long>();
 		this.players = new ArrayList<String>();
 		this.playersTotal = new ArrayList<String>();
-		this.playersPrefix = new HashMap<String, String>();
+               this.playersPrefix = new HashMap<String, String>();
+               this.scoreboardTeamIds = new HashMap<String, String>();
 		this.playersObj = new ArrayList<Player>();
 		this.playersTotalObj = new ArrayList<Player>();
 		this.playersGanadores = new ArrayList<Player>();
@@ -104,9 +110,10 @@ public class MatchPlayerHandler {
 		this.playersVanish = new ArrayList<Player>();
 		this.paintPlayers = new HashSet<Player>();
 		this.playerToKill = new HashSet<Player>();
-		this.playersPrefix = new HashMap<String, String>();
+               this.playersPrefix = new HashMap<String, String>();
+               this.scoreboardTeamIds = new HashMap<String, String>();
 
-		this.equipos = new HashMap<Integer, Set<Player>>();
+               this.equipos = new HashMap<Integer, Set<Player>>();
 		this.teamsCopy = new HashMap<Integer, Set<Player>>();
 
 		this.goalPlayers = new ArrayList<Player>();
@@ -279,13 +286,21 @@ public class MatchPlayerHandler {
 		this.paintedLocations = paintedLocations;
 	}
 
-	public Map<String, String> getPlayersPrefix() {
-		return playersPrefix;
-	}
+        public Map<String, String> getPlayersPrefix() {
+                return playersPrefix;
+        }
 
-	public void setPlayersPrefix(Map<String, String> playersPrefix) {
-		this.playersPrefix = playersPrefix;
-	}
+        public void setPlayersPrefix(Map<String, String> playersPrefix) {
+                this.playersPrefix = playersPrefix;
+        }
+
+       public Map<String, String> getScoreboardTeamIds() {
+               return scoreboardTeamIds;
+       }
+
+       public void setScoreboardTeamIds(Map<String, String> scoreboardTeamIds) {
+               this.scoreboardTeamIds = scoreboardTeamIds;
+       }
 
 	public Map<String, Long> getPlayersInvincible() {
 		return playersInvincible;


### PR DESCRIPTION
## Summary
- handle long player names when creating scoreboard teams
- track scoreboard team identifiers for each player

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68573602a4dc8330ac40d80534fd1837