### PR TITLE
Remove legacy MaterialData usage

### DIFF
--- a/RandomEvents/src/com/immortalman01/api/API1711.java
+++ b/RandomEvents/src/com/immortalman01/api/API1711.java
@@ -11,7 +11,6 @@ import org.bukkit.entity.Fireball;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.material.MaterialData;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.util.Vector;
 
@@ -83,13 +82,9 @@ public class API1711 {
         try {
             Block b = loc.getBlock();
             if (data instanceof BlockData) {
-                b.setBlockData(((BlockData) data));
-            } else if (data instanceof MaterialData) {
-                MaterialData md = (MaterialData) data;
-                b.setType(md.getItemType());
-                try {
-                    b.setBlockData(Bukkit.createBlockData(md.getItemType()));
-                } catch (Throwable ignore) {}
+                b.setBlockData((BlockData) data);
+            } else if (data instanceof org.bukkit.Material) {
+                b.setType((org.bukkit.Material) data);
             }
         } catch (Throwable ignore) {}
     }

--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -16,7 +16,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.MaterialData;
+import org.bukkit.Material;
 
 import com.immortalman01.randomevents.RandomEvents;
 import com.immortalman01.randomevents.match.Kit;
@@ -1257,7 +1257,7 @@ public class Chat implements Listener {
 								match.setInventoryBeast(null);
 								match.setInventoryRunners(null);
 								match.setMaterial(null);
-								match.setDatas(new ArrayList<MaterialData>());
+                                                                match.setDatas(new ArrayList<Material>());
 								plugin.getPlayersCreation().remove(player.getName());
 
 								// actualiza =
@@ -1514,13 +1514,9 @@ public class Chat implements Listener {
 						if (message.equalsIgnoreCase(Constantes.DONE)) {
 							if (player.getInventory().getItemInMainHand() != null
 									&& player.getInventory().getItemInMainHand().getType() != (XMaterial.AIR.parseMaterial())) {
-                                                                try {
-                                                                        MaterialData mat = new MaterialData(player.getInventory().getItemInMainHand().getType(),
-                                                                                player.getInventory().getItemInMainHand().getData().getData());
-                                                                        match.getDatas().add(mat);
-                                                                } catch (Throwable eb) {
-                                                                        match.getDatas().add(player.getInventory().getItemInMainHand().getData());
-                                                                }
+                                                                // Store the material type directly
+                                                                Material mat = player.getInventory().getItemInMainHand().getType();
+                                                                match.getDatas().add(mat);
 								plugin.getPlayersCreation().remove(player.getName());
 
 							} else {
@@ -1535,9 +1531,9 @@ public class Chat implements Listener {
                                                         if (player.getInventory().getItemInMainHand() != null
                                                                         && player.getInventory().getItemInMainHand().getType() != (XMaterial.AIR.parseMaterial())) {
                                                                 // Use only the material type to avoid legacy data lookups
-                                                                MaterialData mat = new MaterialData(player.getInventory().getItemInMainHand().getType());
+                                                                Material mat = player.getInventory().getItemInMainHand().getType();
                                                                 match.getDatas().add(mat);
-                                                                match.setMaterial(player.getInventory().getItemInMainHand().getType().toString());
+                                                                match.setMaterial(mat.toString());
                                                                 plugin.getPlayersCreation().remove(player.getName());
                                                                 plugin.getPlayersCreation().put(player.getName(),
                                                                                Creacion.ANOTHER_MATERIAL_SPLEEF.getPosition());
@@ -1564,7 +1560,7 @@ public class Chat implements Listener {
 							if (player.getInventory().getItemInMainHand() != null
 									&& player.getInventory().getItemInMainHand().getType() != (XMaterial.AIR.parseMaterial())) {
                                                                 // Only store the material type to avoid legacy data usage
-                                                                MaterialData mat = new MaterialData(player.getInventory().getItemInMainHand().getType());
+                                                                Material mat = player.getInventory().getItemInMainHand().getType();
                                                                 match.getDatas().add(mat);
                                                                 plugin.getPlayersCreation().remove(player.getName());
                                                                 actua = Boolean.FALSE;
@@ -1797,7 +1793,7 @@ public class Chat implements Listener {
 								match.setInventoryBeast(null);
 								match.setInventoryRunners(null);
 								match.setMaterial(null);
-								match.setDatas(new ArrayList<MaterialData>());
+                                                                match.setDatas(new ArrayList<Material>());
 
 								break;
 							case BATTLE_NAME:
@@ -1901,7 +1897,7 @@ public class Chat implements Listener {
 							case BLOCKS_ALLOWED:
 							case MATERIAL_SPLEEF:
                                                         case ANOTHER_MATERIAL_SPLEEF:
-                                                                match.setDatas(new ArrayList<MaterialData>());
+                                                                match.setDatas(new ArrayList<Material>());
                                                                 break;
                                                         case SNOWBALL_SPLEEF:
                                                                 match.setSnowballSpleef(null);

--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
@@ -127,7 +127,7 @@ public class Use implements Listener {
                                                         || (plugin.getMatchActive().getMatch().getDatas() != null
                                                                         && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
                                                                         && evt.getClickedBlock().getType() != null
-                                                                        && UtilsRandomEvents.contieneMaterialData(evt.getClickedBlock(),
+                                                                        && UtilsRandomEvents.containsMaterial(evt.getClickedBlock(),
                                                                                plugin.getMatchActive().getMatch()))) {
 						Integer equipo = plugin.getMatchActive().getEquipoCopy(player);
 						Petos peto = Petos.getPeto(equipo);
@@ -496,7 +496,7 @@ public class Use implements Listener {
                                                         || (plugin.getMatchActive().getMatch().getDatas() != null
                                                                         && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
                                                                         && nextBlock.getType() != null
-                                                                        && UtilsRandomEvents.contieneMaterialData(nextBlock,
+                                                                        && UtilsRandomEvents.containsMaterial(nextBlock,
                                                                                plugin.getMatchActive().getMatch()))) {
                                                 plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(nextBlock.getLocation(),
                                                                 nextBlock.getBlockData().clone());
@@ -531,9 +531,9 @@ public class Use implements Listener {
 
 				if (blockFace != null) {
 
-					List<Block> blocks = UtilsRandomEvents.getNearbyBlocks(plugin.getMatchActive().getMatch(),
-							nextBlock.getLocation(), plugin.getReventConfig().getSplatoonRadius(),
-							plugin.getMatchActive().getMatch().getDatas(), true, plugin);
+                                        List<Block> blocks = UtilsRandomEvents.getNearbyBlocks(plugin.getMatchActive().getMatch(),
+                                                        nextBlock.getLocation(), plugin.getReventConfig().getSplatoonRadius(),
+                                                        true, plugin);
 					List<Location> locations = new ArrayList<Location>();
 
 					List<Location> locTeam = new ArrayList<Location>();
@@ -655,7 +655,7 @@ public class Use implements Listener {
                                                         || (plugin.getMatchActive().getMatch().getDatas() != null
                                                                         && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
                                                                         && block.getType() != null
-                                                                        && UtilsRandomEvents.contieneMaterialData(block,
+                                                                        && UtilsRandomEvents.containsMaterial(block,
                                                                                plugin.getMatchActive().getMatch()))) {
                                                 try {
                                                         plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(block.getLocation(),
@@ -788,7 +788,7 @@ public class Use implements Listener {
                                                                                 && plugin.getMatchActive().getMatch().getDatas() != null
                                                                                 && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
                                                                                 && evt.getBlock().getType() != null
-                                                                                && UtilsRandomEvents.contieneMaterialData(evt.getBlock(), plugin.getMatchActive().getMatch()))) {
+&& UtilsRandomEvents.containsMaterial(evt.getBlock(), plugin.getMatchActive().getMatch()))) {
 							evt.setCancelled(true);
                                                        plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(
                                                                        evt.getBlock().getLocation(),
@@ -806,7 +806,7 @@ public class Use implements Listener {
                                                                                 || (plugin.getMatchActive().getMatch().getDatas() != null
                                                                                                 && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
                                                                                                 && evt.getBlock().getType() != null
-                        && UtilsRandomEvents.contieneMaterialData(evt.getBlock(),
+                        && UtilsRandomEvents.containsMaterial(evt.getBlock(),
                                                                                                                 plugin.getMatchActive().getMatch())))) {
 							evt.setCancelled(true);
                                                        plugin.getMatchActive().getMapHandler().getBlockDisappeared().put(
@@ -887,7 +887,7 @@ public class Use implements Listener {
                                                 || (plugin.getMatchActive().getMatch().getDatas() != null
                                                                 && !plugin.getMatchActive().getMatch().getDatas().isEmpty()
                                                                 && evt.getBlock().getType() != null
-                                                                && UtilsRandomEvents.contieneMaterialData(evt.getBlock(),
+                                                                && UtilsRandomEvents.containsMaterial(evt.getBlock(),
                                                                                plugin.getMatchActive().getMatch()))) {
 					// evt.setCancelled(true);
 					evt.setCancelled(false);
@@ -991,7 +991,7 @@ public class Use implements Listener {
 									|| (plugin.getMatchActive().getMatch().getDatas() != null
 											&& !plugin.getMatchActive().getMatch().getDatas().isEmpty()
                                                                                && l2.getBlock().getType() != null
-											&& (UtilsRandomEvents.contieneMaterialData(l2.getBlock(),
+                                                                               && (UtilsRandomEvents.containsMaterial(l2.getBlock(),
 													plugin.getMatchActive().getMatch())
 													|| l2.getBlock().getType().equals(XMaterial.ANVIL.parseMaterial())
 													|| l2.getBlock().getType()

--- a/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
@@ -8,7 +8,7 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.material.MaterialData;
+import org.bukkit.Material;
 
 import com.immortalman01.randomevents.match.enums.MinigameType;
 import com.immortalman01.randomevents.match.utils.InventoryPers;
@@ -84,7 +84,8 @@ public class Match implements Comparable<Match> {
 
 	private String material;
 
-	private List<MaterialData> datas;
+       /** Materials allowed for block interactions in certain minigames. */
+       private List<Material> datas;
 	
 	private Boolean allMaterialAllowed;
 
@@ -123,7 +124,7 @@ public class Match implements Comparable<Match> {
 		this.entitySpawns = new ArrayList<Location>();
 		this.spawns = new ArrayList<Location>();
 		this.spectatorSpawns = new ArrayList<Location>();
-		this.datas = new ArrayList<MaterialData>();
+               this.datas = new ArrayList<Material>();
 		this.scenes = new ArrayList<String>();
 		this.kits = new ArrayList<String>();
 		this.commandsOnStart = new ArrayList<String>();
@@ -377,12 +378,12 @@ public class Match implements Comparable<Match> {
 		this.material = material;
 	}
 
-	public List<MaterialData> getDatas() {
-		return datas;
-	}
+       public List<Material> getDatas() {
+               return datas;
+       }
 
-	public void setDatas(List<MaterialData> datas) {
-		this.datas = datas;
+       public void setDatas(List<Material> datas) {
+               this.datas = datas;
 	}
 
 	public InventoryPers getInventoryChests() {

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -55,7 +55,6 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.material.MaterialData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
@@ -1855,10 +1854,12 @@ public class UtilsRandomEvents {
 		return tamanyo;
 	}
 
-        public static boolean contieneMaterialData(Block block, Match match) {
-                for (MaterialData data : match.getDatas()) {
-                        Material mat = block.getType();
-                        if (data.getItemType() == mat) {
+        /**
+         * Check if the given block's material is included in the match's allowed list.
+         */
+        public static boolean containsMaterial(Block block, Match match) {
+                for (Material matAllowed : match.getDatas()) {
+                        if (block.getType() == matAllowed) {
                                 return true;
                         }
                 }
@@ -2484,12 +2485,12 @@ public class UtilsRandomEvents {
 					case BLOCKS_ALLOWED:
 					case MATERIAL_SPLEEF:
 					case ANOTHER_MATERIAL_SPLEEF:
-						if (match.getDatas() != null && !match.getDatas().isEmpty()) {
-							for (MaterialData s : match.getDatas()) {
-								info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 "
-										+ s.getItemType().toString() + " : " + s.getData();
-							}
-						}
+                                                if (match.getDatas() != null && !match.getDatas().isEmpty()) {
+                                                        for (Material s : match.getDatas()) {
+                                                                info += Constantes.SALTO_LINEA + Constantes.TABULACION + "§9 "
+                                                                               + s.toString();
+                                                        }
+                                                }
 						break;
 					case WATER_DROP_SCENES:
 						if (match.getScenes() != null && !match.getScenes().isEmpty()) {
@@ -3723,16 +3724,16 @@ public class UtilsRandomEvents {
 
 	}
 
-	public static List<Block> getNearbyBlocks(Match match, Location location, int radius, List<MaterialData> datas,
-			Boolean wool, RandomEvents plugin) {
+        public static List<Block> getNearbyBlocks(Match match, Location location, int radius, Boolean wool, RandomEvents plugin) {
 		List<Block> blocks = new ArrayList<Block>();
 		for (int x = location.getBlockX() - radius; x <= location.getBlockX() + radius; x++) {
 			for (int y = location.getBlockY() - radius; y <= location.getBlockY() + radius; y++) {
 				for (int z = location.getBlockZ() - radius; z <= location.getBlockZ() + radius; z++) {
 					Location loc = new Location(location.getWorld(), x, y, z);
-					if (datas == null || (loc.getBlock() != null && loc.getBlock().getType() != null
-							&& (UtilsRandomEvents.contieneMaterialData(loc.getBlock(), match)
-									|| (wool && loc.getBlock().getType().toString().toUpperCase().contains("WOOL"))))) {
+                                        if (match.getDatas() == null || match.getDatas().isEmpty()
+                                                        || (loc.getBlock() != null && loc.getBlock().getType() != null
+                                                                        && (UtilsRandomEvents.containsMaterial(loc.getBlock(), match)
+                                                                                        || (wool && loc.getBlock().getType().toString().toUpperCase().contains("WOOL"))))) {
 
 						blocks.add(loc.getBlock());
 					}

--- a/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/UseMineEventTest.java
+++ b/RandomEvents/src/test/java/com/immortalman01/randomevents/listeners/UseMineEventTest.java
@@ -10,7 +10,6 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.material.MaterialData;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.Location;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,7 +59,6 @@ public class UseMineEventTest {
         when(block.getLocation()).thenReturn(Mockito.mock(Location.class));
         when(block.getBlockData()).thenReturn(Mockito.mock(BlockData.class));
         when(block.getState()).thenReturn(state);
-        when(state.getData()).thenReturn(new MaterialData(Material.DIRT));
 
         when(plugin.getMatchActive()).thenReturn(active);
         when(plugin.getReventConfig()).thenReturn(config);
@@ -110,8 +108,8 @@ public class UseMineEventTest {
         when(match.getMinigame()).thenReturn(MinigameType.SPLEEF);
         when(match.getMaterial()).thenReturn("SNOW_BLOCK");
         when(match.getAllMaterialAllowed()).thenReturn(false);
-        List<MaterialData> datas = new ArrayList<>();
-        datas.add(new MaterialData(Material.DIRT));
+        List<Material> datas = new ArrayList<>();
+        datas.add(Material.DIRT);
         when(match.getDatas()).thenReturn(datas);
 
         use.onMine(event);


### PR DESCRIPTION
## Summary
- modernize Match class to store `Material` instead of `MaterialData`
- update Chat and Use listeners to use `Material` lists
- drop MaterialData API usage in API1711 and UtilsRandomEvents
- adjust unit test for new material handling

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6857492191b08330bde40126e55c010f