### PR TITLE
Fix legacy material lag in team item

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -4824,20 +4824,18 @@ public class MatchActive {
 		if (teamItem != null) {
 			Integer pos = p.getInventory().first(teamItem);
 			if (pos >= 0) {
-				Petos peto = Petos.getPeto(getEquipo(p));
-				if (peto != null) {
-					teamItem.setType(peto.getClay().parseMaterial());
-					try {
-						teamItem.setDurability(peto.getDye().getWoolData());
-						teamItem.getData().setData(peto.getDye().getWoolData());
-					} catch (Throwable e) {
-
-					}
-				}
-				p.getInventory().setItem(pos, teamItem);
-				p.updateInventory();
-			}
-		}
+                               Petos peto = Petos.getPeto(getEquipo(p));
+                               if (peto != null) {
+                                       // Simply update the material to the team
+                                       // colour. Using legacy durability APIs
+                                       // caused "Initializing Legacy Material
+                                       // Support" warnings and lag spikes.
+                                       teamItem.setType(peto.getClay().parseMaterial());
+                               }
+                               p.getInventory().setItem(pos, teamItem);
+                               p.updateInventory();
+                       }
+               }
 
 	}
 

--- a/RandomEvents/src/com/immortalman01/randomevents/match/enums/Petos.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/enums/Petos.java
@@ -124,26 +124,25 @@ public enum Petos {
 		return peto;
 	}
 
-	public ItemStack getWoolItem() {
-		ItemStack wool = getWool().parseItem();
-		try {
-			wool.setDurability(getDye().getWoolData());
-			wool.getData().setData(getDye().getWoolData());
-		} catch (Throwable e) {
+       /**
+        * Obtain the wool item for this team colour using modern materials.
+        *
+        * <p>The legacy {@code setDurability} APIs triggered Bukkit's legacy
+        * material support which caused a noticeable lag spike on modern
+        * servers. Since terracotta and wool blocks have a dedicated material
+        * for each colour in 1.20+, simply creating the item with the correct
+        * material is sufficient.</p>
+        */
+       public ItemStack getWoolItem() {
+               return getWool().parseItem();
+       }
 
-		}
-		return wool;
-	}
-	
-	public ItemStack getClayItem() {
-		ItemStack wool = getClay().parseItem();
-		try {
-			wool.setDurability(getDye().getWoolData());
-			wool.getData().setData(getDye().getWoolData());
-		} catch (Throwable e) {
-
-		}
-		return wool;
-	}
+       /**
+        * Obtain the terracotta item for this team colour using modern
+        * materials. Avoids legacy data manipulation.
+        */
+       public ItemStack getClayItem() {
+               return getClay().parseItem();
+       }
 
 }


### PR DESCRIPTION
## Summary
- stop using deprecated ItemStack durability APIs for team item colors
- avoid legacy material lookup when a player selects a team

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685753390304833086e5c5e68299fb2e