### PR TITLE
Fix team selection GUI for modern Spigot

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -405,16 +405,23 @@ public class GUI implements Listener {
                                return;
                        }
 
-                       int topSize = event.getView().getTopInventory().getSize();
-                       int pos = event.getRawSlot();
-                       if (pos < 0 || pos >= topSize) {
-                               return;
-                       }
+                      int topSize = event.getView().getTopInventory().getSize();
+                      int slot = event.getRawSlot();
+                      if (slot < 0 || slot >= topSize) {
+                              return;
+                      }
 
-                       int teamCount = active.getMatch().getNumberOfTeams();
-                       if (pos >= teamCount) {
-                               return;
-                       }
+                      ItemStack icon = event.getCurrentItem();
+                      String name = ChatColor.stripColor(icon.getItemMeta().getDisplayName());
+                      Integer pos = UtilsRandomEvents.teamIndexFromName(name);
+                      if (pos == null) {
+                              return;
+                      }
+
+                      int teamCount = active.getMatch().getNumberOfTeams();
+                      if (pos < 0 || pos >= teamCount) {
+                              return;
+                      }
 
                        Integer equipoActual = active.getEquipo(p);
 

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -3788,6 +3788,29 @@ return res;
 
 }
 
+       /**
+        * Determine the team index associated with a display name in the team
+        * selection GUI. The names are colourised versions of the {@link Petos}
+        * enum values. By stripping colours we can match them reliably across
+        * server versions.
+        *
+        * @param name the coloured or plain team name from the item display name
+        * @return the team index or {@code null} if no match was found
+        */
+       public static Integer teamIndexFromName(String name) {
+               if (name == null) {
+                       return null;
+               }
+
+               String stripped = ChatColor.stripColor(name);
+               for (Petos peto : Petos.values()) {
+                       if (peto.getName().equalsIgnoreCase(stripped)) {
+                               return peto.getTeam();
+                       }
+               }
+               return null;
+       }
+
 public static int parseProbability(String value) {
 if (value == null) {
 return 0;


### PR DESCRIPTION
## Summary
- determine team by the clicked icon instead of raw slot index
- add helper method to map team names to indexes

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68575b8ff3d08330a2264179692cacda