### PR TITLE
Fix team selection GUI

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -405,27 +405,27 @@ public class GUI implements Listener {
                                return;
                        }
 
-                      int topSize = event.getView().getTopInventory().getSize();
-                      int slot = event.getRawSlot();
-                      if (slot < 0 || slot >= topSize) {
-                              return;
-                      }
-
-                     ItemStack icon = event.getCurrentItem();
-                     int pos = event.getRawSlot();
-                     int teamCount = active.getMatch().getNumberOfTeams();
-                     if (pos < 0 || pos >= teamCount) {
-                             // Fallback to name based detection in case menu layout changes
-                             String name = null;
-                             if (icon.hasItemMeta() && icon.getItemMeta().hasDisplayName()) {
-                                     name = icon.getItemMeta().getDisplayName();
-                             }
-                             Integer fallback = UtilsRandomEvents.teamIndexFromName(name);
-                             if (fallback == null || fallback < 0 || fallback >= teamCount) {
-                                     return;
-                             }
-                             pos = fallback;
+                     int topSize = event.getView().getTopInventory().getSize();
+                     int slot = event.getSlot();
+                     if (slot < 0 || slot >= topSize) {
+                             return;
                      }
+
+                    ItemStack icon = event.getCurrentItem();
+                    int pos = slot;
+                    int teamCount = active.getMatch().getNumberOfTeams();
+                    if (pos < 0 || pos >= teamCount) {
+                            // Fallback to name based detection in case menu layout changes
+                            String name = null;
+                            if (icon.hasItemMeta() && icon.getItemMeta().hasDisplayName()) {
+                                    name = icon.getItemMeta().getDisplayName();
+                            }
+                            Integer fallback = UtilsRandomEvents.teamIndexFromName(name);
+                            if (fallback == null || fallback < 0 || fallback >= teamCount) {
+                                    return;
+                            }
+                            pos = fallback;
+                    }
 
                        Integer equipoActual = active.getEquipo(p);
 


### PR DESCRIPTION
## Summary
- use event slot index for team GUI selection

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6857efd122ec83308eaa4d39de5aab32