### PR TITLE
Fix team selection menu

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -405,11 +405,15 @@ public class GUI implements Listener {
                                return;
                        }
 
-                     int topSize = event.getView().getTopInventory().getSize();
-                     int slot = event.getSlot();
-                     if (slot < 0 || slot >= topSize) {
-                             return;
-                     }
+                    int topSize = event.getView().getTopInventory().getSize();
+                    // Use raw slot to handle modern server versions where
+                    // InventoryClickEvent#getSlot() may be relative to the
+                    // clicked inventory. Raw slot is always the index within
+                    // the open view so it correctly maps to our GUI slots.
+                    int slot = event.getRawSlot();
+                    if (slot < 0 || slot >= topSize) {
+                            return;
+                    }
 
                     ItemStack icon = event.getCurrentItem();
                     int pos = slot;


### PR DESCRIPTION
## Summary
- use raw slot index to reliably detect clicked team slot

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6857f17ae0708330b5fcac0606849b1b