### PR TITLE
Fix team GUI click detection

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -75,36 +75,32 @@ public class GUI implements Listener {
 		}
 
                Inventory topInventory = event.getView().getTopInventory();
-               boolean pluginMenu = topInventory != null && topInventory.getHolder() instanceof RandomEventsHolder;
-               if (pluginMenu) {
+               if (topInventory != null && topInventory.getHolder() instanceof RandomEventsHolder) {
+                       RandomEventsHolder holder = (RandomEventsHolder) topInventory.getHolder();
                        // Cancel any attempts to move items from or to the menu.
                        // Using isShiftClick covers quick move actions while
                        // clickedTopInventory handles normal clicks in the menu.
                        if (clickedTopInventory(event) || event.isShiftClick()) {
                                event.setCancelled(true);
                        }
-                       String invTitle = InventoryUtils.getInventoryTitle(event);
 
-                       if (invTitle != null
-                                       && ChatColor.stripColor(invTitle)
-                                                       .contains(ChatColor.stripColor(plugin.getLanguage().getStatsGuiName()))) {
+                       switch (holder.getType()) {
+                       case STATS:
                                if (clickedTopInventory(event)) {
                                        event.setCancelled(true);
                                }
-                       } else if (invTitle != null
-                                       && ChatColor.stripColor(invTitle)
-                                                       .contains(ChatColor.stripColor(plugin.getLanguage().getCreditsGuiName()))) {
+                               break;
+                       case CREDITS:
                                useCreditsGui(event);
-                       } else if (invTitle != null
-                                       && ChatColor.stripColor(invTitle)
-                                                       .contains(ChatColor.stripColor(plugin.getLanguage().getKitGuiName()))) {
+                               break;
+                       case KITS:
                                useKitGUI(event);
-
-                       } else if (invTitle != null
-                                       && ChatColor.stripColor(invTitle)
-                                                       .contains(ChatColor.stripColor(plugin.getLanguage().getTeamGuiName()))) {
+                               break;
+                       case TEAMS:
                                useTeamGUI(event);
-
+                               break;
+                       default:
+                               break;
                        }
                }
        }

--- a/RandomEvents/src/com/immortalman01/randomevents/util/RandomEventsHolder.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/RandomEventsHolder.java
@@ -8,6 +8,20 @@ import org.bukkit.inventory.InventoryHolder;
  * plugin inventories regardless of title conversion across versions.
  */
 public class RandomEventsHolder implements InventoryHolder {
+
+    /** Type of GUI this holder represents. */
+    public enum GuiType { STATS, CREDITS, KITS, TEAMS }
+
+    private final GuiType type;
+
+    public RandomEventsHolder(GuiType type) {
+        this.type = type;
+    }
+
+    public GuiType getType() {
+        return type;
+    }
+
     @Override
     public Inventory getInventory() {
         return null;

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -1736,8 +1736,8 @@ public class UtilsRandomEvents {
 		}
 	}
 
-	public static Inventory createGUI(String name, Stats estadisticas, RandomEvents plugin) {
-               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(),
+       public static Inventory createGUI(String name, Stats estadisticas, RandomEvents plugin) {
+               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(RandomEventsHolder.GuiType.STATS),
                                plugin.getReventConfig().getStatsSize(),
                                plugin.getLanguage().getStatsGuiName() + name);
 		for (MinigameType minigame : MinigameType.values()) {
@@ -3457,9 +3457,9 @@ public class UtilsRandomEvents {
 		return listaPartidas;
 	}
 
-	public static Inventory createGUICredits(Player p, Map<String, Integer> creditos, Integer page,
-			RandomEvents plugin) {
-               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(), 45,
+       public static Inventory createGUICredits(Player p, Map<String, Integer> creditos, Integer page,
+                       RandomEvents plugin) {
+               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(RandomEventsHolder.GuiType.CREDITS), 45,
                                plugin.getLanguage().getCreditsGuiName());
 		ItemStack nextPage = new ItemStack(XMaterial.OAK_SIGN.parseMaterial());
 		ItemStack backPage = new ItemStack(XMaterial.OAK_SIGN.parseMaterial());
@@ -3560,9 +3560,9 @@ public class UtilsRandomEvents {
 		return inv;
 	}
 
-	public static Inventory createGUIKits(Player p, Integer page, RandomEvents plugin, MatchActive matchActive) {
+       public static Inventory createGUIKits(Player p, Integer page, RandomEvents plugin, MatchActive matchActive) {
 
-               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(), 45,
+               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(RandomEventsHolder.GuiType.KITS), 45,
                                plugin.getLanguage().getKitGuiName());
 
 		if (matchActive != null) {
@@ -3570,7 +3570,7 @@ public class UtilsRandomEvents {
 			List<Kit> kitsAvailable = UtilsRandomEvents.kitsAvailable(p, match.getKits(), plugin);
 
 			Integer size = UtilsRandomEvents.sizeGUIKits(kitsAvailable);
-                       inv = Bukkit.createInventory(new RandomEventsHolder(), size,
+                       inv = Bukkit.createInventory(new RandomEventsHolder(RandomEventsHolder.GuiType.KITS), size,
                                        plugin.getLanguage().getKitGuiName());
 			ItemStack nextPage = new ItemStack(XMaterial.OAK_SIGN.parseMaterial());
 			ItemStack backPage = new ItemStack(XMaterial.OAK_SIGN.parseMaterial());
@@ -3615,9 +3615,9 @@ public class UtilsRandomEvents {
 		return inv;
 	}
 
-	public static Inventory createGUITeams(Player p, Integer page, RandomEvents plugin, MatchActive matchActive) {
+       public static Inventory createGUITeams(Player p, Integer page, RandomEvents plugin, MatchActive matchActive) {
 
-               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(), 9,
+               Inventory inv = Bukkit.createInventory(new RandomEventsHolder(RandomEventsHolder.GuiType.TEAMS), 9,
                                plugin.getLanguage().getTeamGuiName());
 
 		if (matchActive != null) {


### PR DESCRIPTION
## Summary
- add `GuiType` to `RandomEventsHolder`
- mark GUI inventories with their type
- use the holder type instead of inventory title to dispatch in `GUI`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6857f2dcc6e88330820db204cafcf4b7