### PR TITLE
Update PBALLTK scoreboard layout

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -4602,7 +4602,11 @@ public class MatchActive {
                                         fBoard = new FastBoard(p);
                                 }
 
-                                fBoard.updateTitle(plugin.getLanguage().getScoreboardTitle());
+                                String title = plugin.getLanguage().getScoreboardTitle();
+                                if (getMatch().getMinigame().equals(MinigameType.PAINTBALL_TOP_KILL)) {
+                                        title = "&9&lRandomEvent";
+                                }
+                                fBoard.updateTitle(title);
 
                                 fBoard.updateLines(UtilsRandomEvents.prepareLines(plugin, this, p));
 

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -2952,10 +2952,9 @@ public class UtilsRandomEvents {
 			}
 			break;
 
-		case HOEHOEHOE:
-		case SPLATOON:
-		case TOP_KILLER_TEAMS:
-               case PAINTBALL_TOP_KILL:
+               case HOEHOEHOE:
+               case SPLATOON:
+               case TOP_KILLER_TEAMS:
 
                        lines.add(plugin.getLanguage().getTranslation("scoreboard.status"));
 
@@ -2999,6 +2998,33 @@ public class UtilsRandomEvents {
                                                .replace("%player%", pl.getName())
                                                .replace("%kills%", "" + pk));
                        }
+
+                       break;
+
+               case PAINTBALL_TOP_KILL:
+
+                       lines.add("&fStatus:");
+
+                       long secondsPBALLTK = (matchActive.getEndDate() - new Date().getTime()) / 1000;
+                       lines.add("&fFINISHING IN &a" + calculateTimeTwoPoints(secondsPBALLTK));
+
+                       lines.add("");
+
+                       // Lives placeholders (not implemented in plugin, default 0)
+                       lines.add("&9Blue &fLives: &a0");
+                       lines.add("&cRed &fLives: &a0");
+
+                       lines.add("");
+
+                       int kills = matchActive.getPuntuacion().getOrDefault(player.getName(), 0);
+                       lines.add("&fYour Kills: &a" + kills);
+
+                       lines.add("");
+
+                       lines.add("&fPlayers:");
+                       int online = matchActive.getPlayerHandler().getPlayersObj().size();
+                       int max = matchActive.getMatch().getAmountPlayers() != null ? matchActive.getMatch().getAmountPlayers() : 0;
+                       lines.add("&a" + online + "&f/&c" + max);
 
                        break;
 		case KOTH:


### PR DESCRIPTION
## Summary
- customize scoreboard lines for Paintball Top Kill
- override scoreboard title for the PBALLTK event

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6857f91d2478833085730eb347d556bf