### PR TITLE
Add configurable scoreboard system

### DIFF
--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -26,14 +26,14 @@ sourceSets {
         java.exclude 'com/immortalman01/randomevents/util/UtilsProtocolLib.java'
         java.exclude 'test/**'
         resources.srcDir '.'
-        resources.includes = ['plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard_pballtk.yml']
+        resources.includes = ['plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml']
     }
 }
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from('.') {
-        include 'plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard_pballtk.yml'
+        include 'plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml'
     }
 }
 

--- a/RandomEvents/scoreboard.yml
+++ b/RandomEvents/scoreboard.yml
@@ -1,0 +1,178 @@
+# Default scoreboard configuration
+# Layout tokens:
+# <TEAM> - Show player's team
+# <TEAMMATE> - Show teammate
+# <TIME_REFILL> - Show refill timer
+# <TIME> - Show time remaining
+# <DEADALIVE> - Show alive/dead players
+# <DEADALIVE_TEAM> - Show alive/dead players with team colors
+# <HOLDER> - Show current holder
+# <BEAST> - Show beast player
+# <SEEKERS> - Show seeker list
+# <ROUNDS> - Show current round
+# <STEP> - Show WaterDrop step info
+# <POINTS> - Show ranking points
+# <TEAM_KILLS> - Show team kill scoreboard
+
+titles:
+  DEFAULT: "&a&l%prefix%"
+  PAINTBALL_TOP_KILL: "&9&lRandomEvent"
+
+events:
+  PAINTBALL:
+    - "<TEAM>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE_TEAM>"
+  BATTLE_ROYALE_TEAMS:
+    - "<TEAM>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE_TEAM>"
+  TSW_REAL:
+    - "<TEAM>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE_TEAM>"
+  BATTLE_ROYALE_TEAM_2:
+    - "<TEAMMATE>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  TSW:
+    - "<TEAMMATE>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  BOMB_TAG:
+    - "<HOLDER>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<DEADALIVE>"
+  TSG_REAL:
+    - "<TEAM>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE_TEAM>"
+  TSG:
+    - "<TEAMMATE>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  SG:
+    - "<TIME>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  BLOCK_PARTY:
+    - "<ROUNDS>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<DEADALIVE>"
+  GLASS_WALK:
+    - "<TIME>"
+    - ""
+    - "<DEADALIVE>"
+  BATTLE_ROYALE:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  BATTLE_ROYALE_CABALLO:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  ESCAPE_ARROW:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  ANVIL_SPLEEF:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  BOMBARDMENT:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  KNOCKBACK_DUEL:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  SPLEEF:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  SPLEGG:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  SW:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  TNT_RUN:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  RACE:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  RED_GREEN_LIGHT:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  ESCAPE_FROM_BEAST:
+    - "<BEAST>"
+    - ""
+    - "<DEADALIVE>"
+  HIDE_AND_SEEK:
+    - "<SEEKERS>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<DEADALIVE>"
+  TOP_KILLER_TEAM_2:
+    - "<TEAMMATE>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  TOP_KILLER:
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  FISH_SLAP:
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  QUAKECRAFT:
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  OITC:
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  HOEHOEHOE:
+    - "<TEAM_KILLS>"
+  SPLATOON:
+    - "<TEAM_KILLS>"
+  TOP_KILLER_TEAMS:
+    - "<TEAM_KILLS>"
+  PAINTBALL_TOP_KILL:
+    - "&fStatus:"
+    - "&fFINISHING IN &a%time%"
+    - ""
+    - "&9Blue &fLives: &a%blueLives%"
+    - "&cRed &fLives: &a%redLives%"
+    - ""
+    - "&fYour Kills: &a%kills%"
+    - ""
+    - "&fPlayers:"
+    - "&a%players%&f/&c%max%"
+  KOTH:
+    - "<HOLDER>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  GEM_CRAWLER:
+    - "<POINTS>"
+  WDROP:
+    - "<STEP>"
+    - ""
+    - "<POINTS>"

--- a/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
@@ -38,6 +38,7 @@ import com.immortalman01.randomevents.commands.GenericCommand;
 import com.immortalman01.randomevents.config.Configuration;
 import com.immortalman01.randomevents.config.ReventConfig;
 import com.immortalman01.randomevents.config.ScoreboardPBALLTKConfig;
+import com.immortalman01.randomevents.config.ScoreboardConfig;
 import com.immortalman01.randomevents.language.LanguageMessages;
 import com.immortalman01.randomevents.listeners.Chat;
 import com.immortalman01.randomevents.listeners.Death;
@@ -114,6 +115,7 @@ public class RandomEvents extends JavaPlugin {
         private ReventConfig reventConfig;
 
         private ScoreboardPBALLTKConfig scoreboardPBALLTKConfig;
+        private ScoreboardConfig scoreboardConfig;
 
 	private HikariCP hikari;
 
@@ -306,6 +308,7 @@ public class RandomEvents extends JavaPlugin {
                 reventConfig = new ReventConfig(this);
                 reventConfig.inicializaVariables();
                 scoreboardPBALLTKConfig = new ScoreboardPBALLTKConfig(this);
+                scoreboardConfig = new ScoreboardConfig(this);
 
         }
 
@@ -725,6 +728,10 @@ public class RandomEvents extends JavaPlugin {
 
         public ScoreboardPBALLTKConfig getScoreboardPBALLTKConfig() {
                 return scoreboardPBALLTKConfig;
+        }
+
+        public ScoreboardConfig getScoreboardConfig() {
+                return scoreboardConfig;
         }
 
 	public HikariCP getHikari() {

--- a/RandomEvents/src/com/immortalman01/randomevents/config/ScoreboardConfig.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/config/ScoreboardConfig.java
@@ -1,0 +1,31 @@
+package com.immortalman01.randomevents.config;
+
+import java.util.List;
+
+import org.bukkit.ChatColor;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class ScoreboardConfig extends Configuration {
+
+    public ScoreboardConfig(JavaPlugin plugin) {
+        super(plugin, "scoreboard.yml");
+    }
+
+    public List<String> getLayout(String key) {
+        return getStringList("events." + key);
+    }
+
+    public String getTitle(String key) {
+        String path = "titles." + key;
+        if (isString(path)) {
+            return color(getString(path));
+        }
+        String def = getString("titles.DEFAULT");
+        return color(def);
+    }
+
+    public static String color(String s) {
+        if (s == null) return null;
+        return ChatColor.translateAlternateColorCodes('&', s);
+    }
+}

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -4602,10 +4602,7 @@ public class MatchActive {
                                         fBoard = new FastBoard(p);
                                 }
 
-                                String title = plugin.getLanguage().getScoreboardTitle();
-                                if (getMatch().getMinigame().equals(MinigameType.PAINTBALL_TOP_KILL)) {
-                                        title = "&9&lRandomEvent";
-                                }
+                                String title = plugin.getScoreboardConfig().getTitle(getMatch().getMinigame().name());
                                 fBoard.updateTitle(title);
 
                                 fBoard.updateLines(UtilsRandomEvents.prepareLines(plugin, this, p));

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -77,6 +77,7 @@ import com.immortalman01.randomevents.match.utils.Cuboid;
 import com.immortalman01.randomevents.match.utils.InventoryPers;
 import com.immortalman01.randomevents.stats.Stats;
 import com.immortalman01.randomevents.config.ScoreboardPBALLTKConfig;
+import com.immortalman01.randomevents.config.ScoreboardConfig;
 import com.immortalman01.randomevents.util.RandomEventsHolder;
 import com.immortalman01.util.enums.Particle1711;
 import com.immortalman01.util.enums.ParticleDisplay;
@@ -2840,8 +2841,17 @@ public class UtilsRandomEvents {
 		List<Player> playersDeadObj = new ArrayList<Player>();
 		playersDeadObj.addAll(matchActive.getPlayerHandler().getPlayersTotalObj());
 		playersDeadObj.removeAll(matchActive.getPlayerHandler().getPlayersObj());
-		lines.add("");
-		switch (matchActive.getMatch().getMinigame()) {
+                lines.add("");
+
+                List<String> customLayout = plugin.getScoreboardConfig().getLayout(matchActive.getMatch().getMinigame().name());
+                if (customLayout != null && !customLayout.isEmpty()) {
+                        for (String token : customLayout) {
+                                addTokenLines(token, lines, plugin, matchActive, player, playersDead, playersDeadObj);
+                        }
+                        return finalizeLines(lines);
+                }
+
+                switch (matchActive.getMatch().getMinigame()) {
 		case PAINTBALL:
 		case BATTLE_ROYALE_TEAMS:
 		case TSW_REAL:
@@ -3142,8 +3152,8 @@ public class UtilsRandomEvents {
 		return lines;
 	}
 
-	private static List<String> prepareLinesBeast(List<String> lines, MatchActive matchActive, RandomEvents plugin,
-			Player player) {
+        private static List<String> prepareLinesBeast(List<String> lines, MatchActive matchActive, RandomEvents plugin,
+                        Player player) {
 		if (matchActive.getPlayerHandler().getPlayerContador() == null) {
 			lines.add(plugin.getLanguage().getScoreboardBeast().replaceAll("%name%", "-"));
 		} else {
@@ -3151,8 +3161,125 @@ public class UtilsRandomEvents {
 					matchActive.getPlayerHandler().getPlayerContador().getName()));
 
 		}
-		return lines;
-	}
+                return lines;
+        }
+
+        private static void addTokenLines(String token, List<String> lines, RandomEvents plugin, MatchActive matchActive,
+                        Player player, List<String> playersDead, List<Player> playersDeadObj) {
+                switch (token) {
+                case "<TEAM>":
+                        prepareLinesTeam(lines, matchActive, plugin, player);
+                        break;
+                case "<TEAMMATE>":
+                        prepareLinesTeammate(lines, matchActive, plugin, player);
+                        break;
+                case "<TIME_REFILL>":
+                        prepareLinesTimeRefill(lines, plugin, matchActive);
+                        break;
+                case "<TIME>":
+                        prepareLinesTime(lines, plugin, matchActive);
+                        break;
+                case "<DEADALIVE>":
+                        prepareLinesDeadAlive(lines, matchActive, plugin, playersDead);
+                        break;
+                case "<DEADALIVE_TEAM>":
+                        prepareLinesDeadAliveTeam(lines, matchActive, plugin, playersDeadObj);
+                        break;
+                case "<HOLDER>":
+                        prepareLinesHolder(lines, matchActive, plugin, player);
+                        break;
+                case "<BEAST>":
+                        prepareLinesBeast(lines, matchActive, plugin, player);
+                        break;
+                case "<SEEKERS>":
+                        prepareLinesSeekers(lines, matchActive, plugin, player);
+                        break;
+                case "<ROUNDS>":
+                        prepareLinesRounds(lines, plugin, matchActive);
+                        break;
+                case "<STEP>":
+                        prepareLinesStep(lines, plugin, matchActive, player);
+                        break;
+                case "<POINTS>":
+                        lines.addAll(prepareLinesPoints(matchActive, plugin, player));
+                        break;
+                case "<TEAM_KILLS>":
+                        lines.addAll(prepareLinesTeamKills(matchActive, plugin, player));
+                        break;
+                default:
+                        lines.add(ScoreboardConfig.color(token));
+                        break;
+                }
+        }
+
+        private static List<String> prepareLinesPoints(MatchActive matchActive, RandomEvents plugin, Player player) {
+                List<String> result = new ArrayList<String>();
+                switch (matchActive.getMatch().getMinigame()) {
+                case WDROP:
+                        Map<Player, Integer> mapaOrdenadoStep = sortByValue(matchActive.getStep(), true);
+                        for (Entry<Player, Integer> entrada : mapaOrdenadoStep.entrySet()) {
+                                result.add(plugin.getLanguage().getScoreboardPoints()
+                                                .replaceAll("%name%", entrada.getKey().getName())
+                                                .replaceAll("%points%", "" + (entrada.getValue() + 1)));
+                        }
+                        break;
+                default:
+                        Map<String, Integer> mapaOrdenado = sortByValue(matchActive.getPuntuacion(), true);
+                        for (Entry<String, Integer> entrada : mapaOrdenado.entrySet()) {
+                                result.add(plugin.getLanguage().getScoreboardPoints()
+                                                .replaceAll("%name%", entrada.getKey())
+                                                .replaceAll("%points%", "" + entrada.getValue()));
+                        }
+                        break;
+                }
+                return result;
+        }
+
+        private static List<String> prepareLinesTeamKills(MatchActive matchActive, RandomEvents plugin, Player player) {
+                List<String> lines = new ArrayList<String>();
+                lines.add(plugin.getLanguage().getTranslation("scoreboard.status"));
+                long secondsTopKill = (matchActive.getEndDate() - new Date().getTime()) / 1000;
+                lines.add(plugin.getLanguage().getTranslation("scoreboard.endsin")
+                                .replace("%time%", calculateTimeTwoPoints(secondsTopKill)));
+                lines.add(plugin.getLanguage().getTranslation("scoreboard.bluelives").replace("%lives%", "0"));
+                lines.add(plugin.getLanguage().getTranslation("scoreboard.redlives").replace("%lives%", "0"));
+                lines.add("");
+                int killsTop = matchActive.getPuntuacion().getOrDefault(player.getName(), 0);
+                lines.add(plugin.getLanguage().getScoreboardYourKills().replaceAll("%kills%", "" + killsTop));
+                lines.add("");
+                lines.add(plugin.getLanguage().getTranslation("scoreboard.teamblue"));
+                Set<Player> blueTeam = matchActive.getPlayerHandler().getEquipos().getOrDefault(1, new HashSet<Player>());
+                for (Player pl : blueTeam) {
+                        int pk = matchActive.getPuntuacion().getOrDefault(pl.getName(), 0);
+                        lines.add(plugin.getLanguage().getTranslation("scoreboard.teamkill")
+                                        .replace("%player%", pl.getName()).replace("%kills%", "" + pk));
+                }
+                lines.add("");
+                lines.add(plugin.getLanguage().getTranslation("scoreboard.teamred"));
+                Set<Player> redTeam = matchActive.getPlayerHandler().getEquipos().getOrDefault(0, new HashSet<Player>());
+                for (Player pl : redTeam) {
+                        int pk = matchActive.getPuntuacion().getOrDefault(pl.getName(), 0);
+                        lines.add(plugin.getLanguage().getTranslation("scoreboard.teamkill")
+                                        .replace("%player%", pl.getName()).replace("%kills%", "" + pk));
+                }
+                return lines;
+        }
+
+        private static List<String> finalizeLines(List<String> lines) {
+                lines.add("");
+                if (lines.size() > 15) {
+                        lines = lines.subList(0, 15);
+                }
+                List<String> linesFormated = new ArrayList<String>();
+                for (String l : lines) {
+                        if (l.length() > 30) {
+                                linesFormated.add(l.substring(0, 29));
+                        } else {
+                                linesFormated.add(l);
+                        }
+                }
+                return linesFormated;
+        }
 
 	private static List<String> prepareLinesHolder(List<String> lines, MatchActive matchActive, RandomEvents plugin,
 			Player player) {


### PR DESCRIPTION
## Summary
- support new scoreboard.yml file for configuring scoreboard layouts and titles
- load ScoreboardConfig in plugin initialization
- use scoreboard configuration when creating scoreboards
- process scoreboard tokens in `UtilsRandomEvents` for flexible layouts
- update build scripts and resources

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_685811eb57ec8330becf52a51fd725b1