### PR TITLE
Fix scoreboard placeholders

### DIFF
--- a/RandomEvents/src/com/immortalman01/util/FastBoard.java
+++ b/RandomEvents/src/com/immortalman01/util/FastBoard.java
@@ -1,6 +1,9 @@
 package com.immortalman01.util;
 
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -9,12 +12,14 @@ import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.scoreboard.Score;
+import org.bukkit.scoreboard.Team;
 import org.bukkit.entity.Player;
 
 public class FastBoard {
     private final Player player;
     private final Scoreboard scoreboard;
     private final Objective objective;
+    private final Map<Integer, Team> teams = new HashMap<>();
 
     public FastBoard(Player player) {
         this.player = player;
@@ -43,13 +48,41 @@ public class FastBoard {
     }
 
     public void updateLines(List<String> lines) {
-        for (String entry : scoreboard.getEntries()) {
-            scoreboard.resetScores(entry);
+        // Remove unused teams if the scoreboard size decreased
+        for (Iterator<Map.Entry<Integer, Team>> it = teams.entrySet().iterator(); it.hasNext(); ) {
+            Map.Entry<Integer, Team> e = it.next();
+            if (e.getKey() >= lines.size()) {
+                Team t = e.getValue();
+                for (String entry : t.getEntries()) {
+                    scoreboard.resetScores(entry);
+                }
+                t.unregister();
+                it.remove();
+            }
         }
+
         int scoreValue = lines.size();
-        for (String line : lines) {
-            String colored = ChatColor.translateAlternateColorCodes('&', line);
-            Score score = objective.getScore(colored);
+        for (int i = 0; i < lines.size(); i++) {
+            String rawLine = lines.get(i);
+            String colored = ChatColor.translateAlternateColorCodes('&', rawLine);
+
+            String entry = ChatColor.values()[Math.min(i, ChatColor.values().length - 1)].toString();
+            Team team = teams.computeIfAbsent(i, key -> {
+                Team t = scoreboard.getTeam("fb" + key);
+                if (t == null) {
+                    t = scoreboard.registerNewTeam("fb" + key);
+                }
+                t.addEntry(entry);
+                return t;
+            });
+
+            String prefix = colored.length() > 16 ? colored.substring(0, 16) : colored;
+            String suffix = colored.length() > 16 ? colored.substring(16, Math.min(colored.length(), 32)) : "";
+
+            team.setPrefix(prefix);
+            team.setSuffix(suffix);
+
+            Score score = objective.getScore(entry);
             score.setScore(scoreValue--);
         }
     }


### PR DESCRIPTION
## Summary
- support scoreboard lines longer than 16 chars using teams
- this allows placeholders like `%time%` to appear correctly

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68582a70a08c83309143f60c4a16ac05