### PR TITLE
Fix scoreboard placeholders

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/config/ScoreboardConfig.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/config/ScoreboardConfig.java
@@ -25,7 +25,7 @@ public class ScoreboardConfig extends Configuration {
     }
 
     public List<String> getLines(String key) {
-        return getStringList(key);
+        return getStringList("events." + key);
     }
 
     public static String color(String s) {

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -4603,6 +4603,9 @@ public class MatchActive {
                                 }
 
                                 String title = plugin.getScoreboardConfig().getTitle(getMatch().getMinigame().name());
+                                if (title != null) {
+                                        title = title.replace("%prefix%", plugin.getLanguage().getTagPlugin());
+                                }
                                 fBoard.updateTitle(title);
 
                                 fBoard.updateLines(UtilsRandomEvents.prepareLines(plugin, this, p));


### PR DESCRIPTION
## Summary
- read scoreboard custom line definitions from the `events` section
- replace `%prefix%` placeholder in scoreboard titles before displaying

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_685843317aa88330a1e947a0064cb046