### PR TITLE
Fix scoreboard placeholders with PlaceholderAPI

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -4602,11 +4603,18 @@ public class MatchActive {
                                         fBoard = new FastBoard(p);
                                 }
 
-                                String title = plugin.getScoreboardConfig().getTitle(getMatch().getMinigame().name());
-                                if (title != null) {
-                                        title = title.replace("%prefix%", plugin.getLanguage().getTagPlugin());
-                                }
-                                fBoard.updateTitle(title);
+                               String title = plugin.getScoreboardConfig().getTitle(getMatch().getMinigame().name());
+                               if (title != null) {
+                                       title = title.replace("%prefix%", plugin.getLanguage().getTagPlugin());
+                                       if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+                                               try {
+                                                       title = PlaceholderAPI.setPlaceholders(p, title);
+                                               } catch (Exception e) {
+                                                       // ignore placeholder errors
+                                               }
+                                       }
+                               }
+                               fBoard.updateTitle(title);
 
                                 fBoard.updateLines(UtilsRandomEvents.prepareLines(plugin, this, p));
 

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -46,6 +46,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
+import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Firework;
@@ -2844,12 +2845,12 @@ public class UtilsRandomEvents {
                 lines.add("");
 
                 List<String> customLayout = plugin.getScoreboardConfig().getLayout(matchActive.getMatch().getMinigame().name());
-                if (customLayout != null && !customLayout.isEmpty()) {
-                        for (String token : customLayout) {
-                                addTokenLines(token, lines, plugin, matchActive, player, playersDead, playersDeadObj);
-                        }
-                        return finalizeLines(lines);
-                }
+               if (customLayout != null && !customLayout.isEmpty()) {
+                       for (String token : customLayout) {
+                               addTokenLines(token, lines, plugin, matchActive, player, playersDead, playersDeadObj);
+                       }
+                       return finalizeLines(lines, plugin, player);
+               }
 
                 switch (matchActive.getMatch().getMinigame()) {
 		case PAINTBALL:
@@ -3085,20 +3086,27 @@ public class UtilsRandomEvents {
 		default:
 			break;
 		}
-		lines.add("");
-		if (lines.size() > 15) {
-			lines = lines.subList(0, 15);
-		}
-		List<String> linesFormated = new ArrayList<String>();
-		for (String l : lines) {
-			if (l.length() > 30) {
-				linesFormated.add(l.substring(0, 29));
-			} else {
-				linesFormated.add(l);
-			}
-		}
-		lines = linesFormated;
-		return lines;
+               lines.add("");
+               if (lines.size() > 15) {
+                       lines = lines.subList(0, 15);
+               }
+               List<String> linesFormated = new ArrayList<String>();
+               for (String l : lines) {
+                       if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+                               try {
+                                       l = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, l);
+                               } catch (Exception e) {
+                                       // ignore placeholder errors
+                               }
+                       }
+                       if (l.length() > 30) {
+                               linesFormated.add(l.substring(0, 29));
+                       } else {
+                               linesFormated.add(l);
+                       }
+               }
+               lines = linesFormated;
+               return lines;
 	}
 
 	private static List<String> prepareLinesRounds(List<String> lines, RandomEvents plugin, MatchActive matchActive) {
@@ -3265,21 +3273,28 @@ public class UtilsRandomEvents {
                 return lines;
         }
 
-        private static List<String> finalizeLines(List<String> lines) {
-                lines.add("");
-                if (lines.size() > 15) {
-                        lines = lines.subList(0, 15);
-                }
-                List<String> linesFormated = new ArrayList<String>();
-                for (String l : lines) {
-                        if (l.length() > 30) {
-                                linesFormated.add(l.substring(0, 29));
-                        } else {
-                                linesFormated.add(l);
-                        }
-                }
-                return linesFormated;
-        }
+       private static List<String> finalizeLines(List<String> lines, RandomEvents plugin, Player player) {
+               lines.add("");
+               if (lines.size() > 15) {
+                       lines = lines.subList(0, 15);
+               }
+               List<String> linesFormated = new ArrayList<String>();
+               for (String l : lines) {
+                       if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+                               try {
+                                       l = me.clip.placeholderapi.PlaceholderAPI.setPlaceholders(player, l);
+                               } catch (Exception e) {
+                                       // ignore placeholder errors
+                               }
+                       }
+                       if (l.length() > 30) {
+                               linesFormated.add(l.substring(0, 29));
+                       } else {
+                               linesFormated.add(l);
+                       }
+               }
+               return linesFormated;
+       }
 
 	private static List<String> prepareLinesHolder(List<String> lines, MatchActive matchActive, RandomEvents plugin,
 			Player player) {


### PR DESCRIPTION
## Summary
- support PlaceholderAPI in scoreboard titles and lines
- update scoreboard line preparation logic to handle placeholders

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68584e74a4508330a8112f33a0e98619