### PR TITLE
Fix scoreboard placeholders in PAINTBALL_TOP_KILL

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -2845,12 +2845,14 @@ public class UtilsRandomEvents {
                 lines.add("");
 
                 List<String> customLayout = plugin.getScoreboardConfig().getLayout(matchActive.getMatch().getMinigame().name());
-               if (customLayout != null && !customLayout.isEmpty()) {
-                       for (String token : customLayout) {
-                               addTokenLines(token, lines, plugin, matchActive, player, playersDead, playersDeadObj);
-                       }
-                       return finalizeLines(lines, plugin, player);
-               }
+                boolean tokenLayout = customLayout != null && !customLayout.isEmpty()
+                                && customLayout.get(0).trim().startsWith("<");
+                if (customLayout != null && !customLayout.isEmpty() && tokenLayout) {
+                        for (String token : customLayout) {
+                                addTokenLines(token, lines, plugin, matchActive, player, playersDead, playersDeadObj);
+                        }
+                        return finalizeLines(lines, plugin, player);
+                }
 
                 switch (matchActive.getMatch().getMinigame()) {
 		case PAINTBALL:


### PR DESCRIPTION
## Summary
- detect scoreboard layouts that use tokens vs. plain text
- only treat layouts starting with `<` as tokens and otherwise fall back to placeholder logic

## Testing
- `gradle test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68586d67ee7883309d629608b43cf9de