### PR TITLE
Add message for team selection in Paintball Top Kill

### DIFF
--- a/RandomEvents/messages.yml
+++ b/RandomEvents/messages.yml
@@ -202,6 +202,7 @@ kit.chosen: "&6&lYou chosed %kit_name%"
 kit.removed: "&6&lKit %kit_name% removed"
 kit.itemName: "&6&lKits"
 team.itemName: "&6&lTeam"
+team.chosen: "You joined the %team_color%%team_name% team"
 kit.defaultName: "&6&lKit: %kit_name%"
 kit.defaultLore:
 - '&eChoose it!'

--- a/RandomEvents/messages_tr.yml
+++ b/RandomEvents/messages_tr.yml
@@ -85,6 +85,7 @@ kit.chosen: '&6&l%kit_name% kiti seçildi'
 kit.removed: '&6&l%kit_name% kiti kaldırıldı'
 kit.itemName: '&6&lKitler'
 team.itemName: '&6&lTakım'
+team.chosen: '%team_name% takımını seçtiniz'
 kit.defaultName: '&6&lKit: %kit_name%'
 kit.defaultLore:
 - '&eSeç!'

--- a/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
@@ -283,8 +283,9 @@ public class LanguageMessages {
 
 	private String kitItemName;
 	private String kitDefaultName;
-	private String kitGuiName;
-	private String kitChosen;
+        private String kitGuiName;
+        private String kitChosen;
+        private String teamChosen;
 
 	private String daysFormat;
 	private String hoursFormat;
@@ -5729,8 +5730,8 @@ public class LanguageMessages {
 		this.kitGuiName = kitGuiName;
 	}
 
-	public String getKitChosen() {
-		String s = kitChosen;
+        public String getKitChosen() {
+                String s = kitChosen;
 		try {
 			Matcher match = pattern.matcher(s);
 			Map<String, ChatColor> mapa = new HashMap<String, ChatColor>();
@@ -5747,9 +5748,31 @@ public class LanguageMessages {
 		} catch (Exception e) {
 			s = s.replaceAll("&", "§");
 		}
-		s = s.replaceAll("\\\\n", Constantes.SALTO_LINEA);
-		return s;
-	}
+                s = s.replaceAll("\\\\n", Constantes.SALTO_LINEA);
+                return s;
+        }
+
+        public String getTeamChosen() {
+                String s = teamChosen;
+                try {
+                        Matcher match = pattern.matcher(s);
+                        Map<String, ChatColor> mapa = new HashMap<String, ChatColor>();
+                        while (match.find()) {
+                                String color = s.substring(match.start() + 1, match.end());
+                                Method method = ChatColor.class.getMethod("of", String.class);
+                                ChatColor chatc = (ChatColor) method.invoke(null, color);
+                                mapa.put("&" + color, chatc);
+                        }
+                        for (Entry<String, ChatColor> ent : mapa.entrySet()) {
+                                s = s.replaceAll(ent.getKey(), ent.getValue() + "");
+                        }
+                        s = ChatColor.translateAlternateColorCodes('&', s);
+                } catch (Exception e) {
+                        s = s.replaceAll("&", "§");
+                }
+                s = s.replaceAll("\\\\n", Constantes.SALTO_LINEA);
+                return s;
+        }
 
 	public String getScoreboardPointsTeam() {
 		String s = scoreboardPointsTeam;
@@ -5803,9 +5826,13 @@ public class LanguageMessages {
 		this.scoreboardPointsTeam = scoreboardPointsTeam;
 	}
 
-	public void setKitChosen(String kitChosen) {
-		this.kitChosen = kitChosen;
-	}
+        public void setKitChosen(String kitChosen) {
+                this.kitChosen = kitChosen;
+        }
+
+        public void setTeamChosen(String teamChosen) {
+                this.teamChosen = teamChosen;
+        }
 
 	public List<String> getMinigameDescriptionQUAKE() {
 		return minigameDescriptionQUAKE;

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -3696,6 +3696,18 @@ public class MatchActive {
                crearTeam(p);
                updateTeamChestplate(p);
                updateTeamItem(p);
+               if (match.getMinigame() == MinigameType.PAINTBALL_TOP_KILL) {
+                       Integer team = getEquipo(p);
+                       if (team != null) {
+                               Petos peto = Petos.getPeto(team);
+                               if (peto != null) {
+                                       p.sendMessage(plugin.getLanguage().getTagPlugin()
+                                                       + plugin.getLanguage().getTeamChosen()
+                                                                       .replace("%team_color%", "" + peto.getChatColor())
+                                                                       .replace("%team_name%", peto.getName()));
+                               }
+                       }
+               }
                mandaMensajesEquipo(getPlayerHandler().getEquipos());
        }
 

--- a/RandomEvents/src/com/immortalman01/randomevents/util/Constantes.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/Constantes.java
@@ -496,7 +496,8 @@ public class Constantes {
 
 		TEAM_GUI_NAME("teamGuiName", "team.guiName", "&6&lTeams"),
 
-		KIT_CHOSEN("kitChosen", "kit.chosen", "&6&lYou chosed %kit_name%"),
+                KIT_CHOSEN("kitChosen", "kit.chosen", "&6&lYou chosed %kit_name%"),
+                TEAM_CHOSEN("teamChosen", "team.chosen", "You joined the %team_color%%team_name% team"),
 
 		KIT_ITEM_NAME("kitItemName", "kit.itemName", "&6&lKits"),
 


### PR DESCRIPTION
## Summary
- introduce `TEAM_CHOSEN` message constant
- support new `teamChosen` field in language messages
- provide English and Turkish message keys
- show selected team in chat during Paintball Top Kill

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68587217fc788330a5e05a03e480763b