### PR TITLE
Fix color deserialization

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/json/GsonFactory.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/json/GsonFactory.java
@@ -157,17 +157,19 @@ public class GsonFactory {
     }
 
     @SuppressWarnings("unchecked")
-    private static Map<String, Object> recursiveRemoveClassKey(Map<String, Object> originalMap) {
+    private static Map<String, Object> recursiveReplaceClassKey(Map<String, Object> originalMap, boolean root) {
         Map<String, Object> map = new HashMap<String, Object>();
         for (Entry<String, Object> entry : originalMap.entrySet()) {
-            if (CLASS_KEY.equals(entry.getKey())) {
-                continue;
-            }
             Object value = entry.getValue();
             if (value instanceof Map) {
-                value = recursiveRemoveClassKey((Map<String, Object>) value);
+                value = recursiveReplaceClassKey((Map<String, Object>) value, false);
             }
             map.put(entry.getKey(), value);
+        }
+
+        Object alias = map.remove(CLASS_KEY);
+        if (alias != null && !root) {
+            map.put(ConfigurationSerialization.SERIALIZED_TYPE_KEY, alias);
         }
         return map;
     }
@@ -409,7 +411,7 @@ public class GsonFactory {
                 if(keys.containsKey("meta")) {
                         Map<String, Object> itemmeta = (Map<String, Object>) keys.get("meta");
                         itemmeta = recursiveDoubleToInteger(itemmeta);
-                        itemmeta = recursiveRemoveClassKey(itemmeta);
+                        itemmeta = recursiveReplaceClassKey(itemmeta, true);
                         ItemMeta meta = (ItemMeta) ConfigurationSerialization.deserializeObject(itemmeta, ConfigurationSerialization.getClassByAlias("ItemMeta"));
                         item.setItemMeta(meta);
                 }

--- a/RandomEvents/src/com/immortalman01/randomevents/json/JsonSerializerDeserializer.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/json/JsonSerializerDeserializer.java
@@ -182,7 +182,7 @@ public class JsonSerializerDeserializer<T> {
             if(keys.containsKey("meta")) {
                 Map<String, Object> itemmeta = (Map<String, Object>) keys.get("meta");
                 itemmeta = recursiveDoubleToInteger(itemmeta);
-                itemmeta = recursiveRemoveClassKey(itemmeta);
+                itemmeta = recursiveReplaceClassKey(itemmeta, true);
                 ItemMeta meta = (ItemMeta) ConfigurationSerialization.deserializeObject(itemmeta, ConfigurationSerialization.getClassByAlias("ItemMeta"));
                 item.setItemMeta(meta);
             }
@@ -208,17 +208,19 @@ public class JsonSerializerDeserializer<T> {
         }
 
         @SuppressWarnings("unchecked")
-        private static Map<String, Object> recursiveRemoveClassKey(Map<String, Object> originalMap) {
+        private static Map<String, Object> recursiveReplaceClassKey(Map<String, Object> originalMap, boolean root) {
             Map<String, Object> map = new HashMap<String, Object>();
             for (Entry<String, Object> entry : originalMap.entrySet()) {
-                if (CLASS_KEY.equals(entry.getKey())) {
-                    continue;
-                }
                 Object value = entry.getValue();
                 if (value instanceof Map) {
-                    value = recursiveRemoveClassKey((Map<String, Object>) value);
+                    value = recursiveReplaceClassKey((Map<String, Object>) value, false);
                 }
                 map.put(entry.getKey(), value);
+            }
+
+            Object alias = map.remove(CLASS_KEY);
+            if (alias != null && !root) {
+                map.put(ConfigurationSerialization.SERIALIZED_TYPE_KEY, alias);
             }
             return map;
         }


### PR DESCRIPTION
## Summary
- improve serialization helpers to keep Bukkit class hints
- avoid ItemStack meta errors when loading LeatherArmor colors

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_685874778b7c833080e79e879637fd4c