### PR TITLE
Add messages for killcoin snowballs

### DIFF
--- a/RandomEvents/messages.yml
+++ b/RandomEvents/messages.yml
@@ -208,6 +208,8 @@ killcoins.itemName: "&6&lKill Coins"
 killcoins.moreSnowballsName: "&cMore Snowballs"
 killcoins.moreSnowballsLore: "&7You will receive 32 extra snowballs.;&7Cost: &a2 Killcoins;&aClick to activate!"
 actionbar.killcoins: "Killcoins: %coins%"
+killcoins.snowballsReceived: "&aYou received 32 extra snowballs!"
+killcoins.notEnough: "&cYou don't have enough Killcoins!"
 team.chosen: "You joined the %team_color%%team_name% team"
 kit.defaultName: "&6&lKit: %kit_name%"
 kit.defaultLore:

--- a/RandomEvents/messages_tr.yml
+++ b/RandomEvents/messages_tr.yml
@@ -90,6 +90,8 @@ killcoins.itemName: '&6&lKill Paraları'
 killcoins.moreSnowballsName: '&cDaha Fazla Kar Topu'
 killcoins.moreSnowballsLore: '&732 ekstra kartopu alacaksın.;&7Maliyet: &a2 Killcoin;&aAktifleştirmek için tıkla!'
 actionbar.killcoins: 'Killcoinler: %coins%'
+killcoins.snowballsReceived: '&a32 ekstra kartopu aldınız!'
+killcoins.notEnough: '&cKillcoin miktarı yetersiz!'
 team.chosen: '%team_name% takımını seçtiniz'
 kit.defaultName: '&6&lKit: %kit_name%'
 kit.defaultLore:

--- a/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/language/LanguageMessages.java
@@ -281,6 +281,8 @@ public class LanguageMessages {
         private String killcoinsMoreSnowballsName;
         private String killcoinsMoreSnowballsLore;
         private String actionbarKillcoins;
+        private String killcoinsSnowballsReceived;
+        private String killcoinsNotEnough;
 
 	private String creditsGuiPage;
 
@@ -6039,6 +6041,22 @@ public class LanguageMessages {
 
         public void setKillcoinsMoreSnowballsLore(String killcoinsMoreSnowballsLore) {
                 this.killcoinsMoreSnowballsLore = killcoinsMoreSnowballsLore;
+        }
+
+        public String getKillcoinsSnowballsReceived() {
+                return colorize(killcoinsSnowballsReceived);
+        }
+
+        public void setKillcoinsSnowballsReceived(String killcoinsSnowballsReceived) {
+                this.killcoinsSnowballsReceived = killcoinsSnowballsReceived;
+        }
+
+        public String getKillcoinsNotEnough() {
+                return colorize(killcoinsNotEnough);
+        }
+
+        public void setKillcoinsNotEnough(String killcoinsNotEnough) {
+                this.killcoinsNotEnough = killcoinsNotEnough;
         }
 
         public String getActionbarKillcoins() {

--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/GUI.java
@@ -510,9 +510,11 @@ public class GUI implements Listener {
                                        p.getInventory().addItem(new ItemStack(Material.SNOWBALL, 32));
                                        p.getInventory().setItem(8, active.getKillCoinItem(p));
                                        UtilsRandomEvents.playSound(plugin, p, XSound.ENTITY_PLAYER_LEVELUP);
+                                       p.sendMessage(plugin.getLanguage().getKillcoinsSnowballsReceived());
                                        p.closeInventory();
                                } else {
                                        UtilsRandomEvents.playSound(plugin, p, XSound.ENTITY_VILLAGER_HURT);
+                                       p.sendMessage(plugin.getLanguage().getKillcoinsNotEnough());
                                }
                        }
                }

--- a/RandomEvents/src/com/immortalman01/randomevents/util/Constantes.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/Constantes.java
@@ -511,6 +511,8 @@ public class Constantes {
                 KILLCOINS_MORE_SNOWBALLS_NAME("killcoinsMoreSnowballsName", "killcoins.moreSnowballsName", "&cMore Snowballs"),
                 KILLCOINS_MORE_SNOWBALLS_LORE("killcoinsMoreSnowballsLore", "killcoins.moreSnowballsLore", "&7You will receive 32 extra snowballs.;&7Cost: &a2 Killcoins;&aClick to activate!"),
                 ACTIONBAR_KILLCOINS("actionbarKillcoins", "actionbar.killcoins", "Killcoins: %coins%"),
+                KILLCOINS_SNOWBALLS_RECEIVED("killcoinsSnowballsReceived", "killcoins.snowballsReceived", "&aYou received 32 extra snowballs!"),
+                KILLCOINS_NOT_ENOUGH("killcoinsNotEnough", "killcoins.notEnough", "&cYou don't have enough Killcoins!"),
 
 		KIT_DEFAULT_NAME("kitDefaultName", "kit.defaultName", "&6&lKit: %kit_name%"),
 


### PR DESCRIPTION
## Summary
- localize killcoins messages for buying snowballs
- show chat feedback when buying snowballs from killcoins GUI

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6858b2e29cf483309a7f71af2a30828b