### PR TITLE
Add Turkish scoreboard configuration

### DIFF
--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -26,14 +26,14 @@ sourceSets {
         java.exclude 'com/immortalman01/randomevents/util/UtilsProtocolLib.java'
         java.exclude 'test/**'
         resources.srcDir '.'
-        resources.includes = ['plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml']
+        resources.includes = ['plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml','scoreboard_tr.yml']
     }
 }
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from('.') {
-        include 'plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml'
+        include 'plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml','scoreboard_tr.yml'
     }
 }
 

--- a/RandomEvents/scoreboard_tr.yml
+++ b/RandomEvents/scoreboard_tr.yml
@@ -1,0 +1,178 @@
+# Default scoreboard configuration
+# Layout tokens:
+# <TEAM> - Show player's team
+# <TEAMMATE> - Show teammate
+# <TIME_REFILL> - Show refill timer
+# <TIME> - Show time remaining
+# <DEADALIVE> - Show alive/dead players
+# <DEADALIVE_TEAM> - Show alive/dead players with team colors
+# <HOLDER> - Show current holder
+# <BEAST> - Show beast player
+# <SEEKERS> - Show seeker list
+# <ROUNDS> - Show current round
+# <STEP> - Show WaterDrop step info
+# <POINTS> - Show ranking points
+# <TEAM_KILLS> - Show team kill scoreboard
+
+titles:
+  DEFAULT: "&a&l%prefix%"
+  PAINTBALL_TOP_KILL: "&9&lRandomEvent"
+
+events:
+  PAINTBALL:
+    - "<TEAM>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE_TEAM>"
+  BATTLE_ROYALE_TEAMS:
+    - "<TEAM>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE_TEAM>"
+  TSW_REAL:
+    - "<TEAM>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE_TEAM>"
+  BATTLE_ROYALE_TEAM_2:
+    - "<TEAMMATE>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  TSW:
+    - "<TEAMMATE>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  BOMB_TAG:
+    - "<HOLDER>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<DEADALIVE>"
+  TSG_REAL:
+    - "<TEAM>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE_TEAM>"
+  TSG:
+    - "<TEAMMATE>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  SG:
+    - "<TIME>"
+    - ""
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  BLOCK_PARTY:
+    - "<ROUNDS>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<DEADALIVE>"
+  GLASS_WALK:
+    - "<TIME>"
+    - ""
+    - "<DEADALIVE>"
+  BATTLE_ROYALE:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  BATTLE_ROYALE_CABALLO:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  ESCAPE_ARROW:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  ANVIL_SPLEEF:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  BOMBARDMENT:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  KNOCKBACK_DUEL:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  SPLEEF:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  SPLEGG:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  SW:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  TNT_RUN:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  RACE:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  RED_GREEN_LIGHT:
+    - "<TIME_REFILL>"
+    - "<DEADALIVE>"
+  ESCAPE_FROM_BEAST:
+    - "<BEAST>"
+    - ""
+    - "<DEADALIVE>"
+  HIDE_AND_SEEK:
+    - "<SEEKERS>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<DEADALIVE>"
+  TOP_KILLER_TEAM_2:
+    - "<TEAMMATE>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  TOP_KILLER:
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  FISH_SLAP:
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  QUAKECRAFT:
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  OITC:
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  HOEHOEHOE:
+    - "<TEAM_KILLS>"
+  SPLATOON:
+    - "<TEAM_KILLS>"
+  TOP_KILLER_TEAMS:
+    - "<TEAM_KILLS>"
+  PAINTBALL_TOP_KILL:
+    - "&fDurum:"
+    - "&fBİTİŞE &a%time%"
+    - ""
+    - "&9Mavi &fCanlar: &a%blueLives%"
+    - "&cKırmızı &fCanlar: &a%redLives%"
+    - ""
+    - "&fÖldürmelerin: &a%kills%"
+    - ""
+    - "&fOyuncular:"
+    - "&a%players%&f/&c%max%"
+  KOTH:
+    - "<HOLDER>"
+    - ""
+    - "<TIME>"
+    - ""
+    - "<POINTS>"
+  GEM_CRAWLER:
+    - "<POINTS>"
+  WDROP:
+    - "<STEP>"
+    - ""
+    - "<POINTS>"

--- a/RandomEvents/src/com/immortalman01/randomevents/config/ScoreboardConfig.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/config/ScoreboardConfig.java
@@ -8,7 +8,8 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class ScoreboardConfig extends Configuration {
 
     public ScoreboardConfig(JavaPlugin plugin) {
-        super(plugin, "scoreboard.yml");
+        super(plugin, plugin.getConfig().getString("language", "en").equalsIgnoreCase("tr")
+                ? "scoreboard_tr.yml" : "scoreboard.yml");
     }
 
     public List<String> getLayout(String key) {


### PR DESCRIPTION
## Summary
- support alternate scoreboard file when `language: tr`
- add scoreboard_tr.yml
- include scoreboard_tr.yml in the build

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6858b7450f1483308221d9a28a972143