### PR TITLE
Fix infinite snowballs in PAINTBALL_TOP_KILL

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
@@ -422,11 +422,13 @@ public class Use implements Listener {
 				if (snowball.getShooter() != null && snowball.getShooter() instanceof Player) {
 					Player p = (Player) snowball.getShooter();
                                         if (plugin.getMatchActive().getPlayerHandler().getPlayers().contains(p.getName())) {
-                                                if (plugin.getReventConfig().isInfiniteSnowballs()
-                                                                && !plugin.getMatchActive().getMatch().getMinigame()
-                                                                                .equals(MinigameType.SPLEEF)) {
-                                                        p.getInventory().addItem(XMaterial.SNOWBALL.parseItem());
-                                                }
+                                               if (plugin.getReventConfig().isInfiniteSnowballs()
+                                                               && !plugin.getMatchActive().getMatch().getMinigame()
+.equals(MinigameType.SPLEEF)
+                                                               && !plugin.getMatchActive().getMatch().getMinigame()
+.equals(MinigameType.PAINTBALL_TOP_KILL)) {
+                                                       p.getInventory().addItem(XMaterial.SNOWBALL.parseItem());
+                                               }
                                         }
 				}
 			} else if (evt.getEntity() instanceof EnderPearl) {


### PR DESCRIPTION
## Summary
- avoid replenishing snowballs when playing the PAINTBALL_TOP_KILL event

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6858b8a15c5c833097864d820f37e0d6