### PR TITLE
Add LicenseGate validation

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
@@ -39,6 +39,7 @@ import com.immortalman01.randomevents.config.Configuration;
 import com.immortalman01.randomevents.config.ReventConfig;
 import com.immortalman01.randomevents.config.ScoreboardConfig;
 import com.immortalman01.randomevents.language.LanguageMessages;
+import com.immortalman01.randomevents.license.LicenseGateValidator;
 import com.immortalman01.randomevents.listeners.Chat;
 import com.immortalman01.randomevents.listeners.Death;
 import com.immortalman01.randomevents.listeners.GUI;
@@ -131,6 +132,11 @@ public class RandomEvents extends JavaPlugin {
 		this.api = new API1711("%%__USER__%%", "RandomEvents");
 		this.lastCheck=new Date();
 		logger=getLogger();
+                if(!new com.immortalman01.randomevents.license.LicenseGateValidator("e9409d76-2006-455d-8c64-13b469845b64").validate()) {
+                        getLogger().severe("License validation failed! Disabling plugin.");
+                        getServer().getPluginManager().disablePlugin(this);
+                        return;
+                }
 		logger.info("Loading config...");
 		loadConfig();
 		this.editando = new ArrayList<String>();

--- a/RandomEvents/src/com/immortalman01/randomevents/license/LicenseGateValidator.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/license/LicenseGateValidator.java
@@ -1,0 +1,55 @@
+package com.immortalman01.randomevents.license;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.bukkit.Bukkit;
+
+/**
+ * Simple license validator using DevLeoko's LicenseGate API.
+ */
+public class LicenseGateValidator {
+    private final String apiKey;
+
+    public LicenseGateValidator(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    /**
+     * Attempts to validate the plugin license.
+     *
+     * @return true if the license is valid
+     */
+    public boolean validate() {
+        HttpURLConnection connection = null;
+        try {
+            String hwid = Bukkit.getServer().getIp();
+            if (hwid == null || hwid.isEmpty()) {
+                hwid = "unknown";
+            }
+            URL url = new URL("https://license.leoko.de/api/validate.php?key=" + apiKey + "&hwid=" + hwid);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+            connection.setDoInput(true);
+            int code = connection.getResponseCode();
+            if (code != HttpURLConnection.HTTP_OK) {
+                return false;
+            }
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))) {
+                String response = reader.readLine();
+                return response != null && response.trim().equalsIgnoreCase("VALID");
+            }
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            return false;
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate simple license validation with DevLeoko's LicenseGate API
- block plugin start if license check fails

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6858bdd9fbcc8330a8f153e3aad40712