### PR TITLE
Add license verification via LicenseGate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ RandomEvents, Minecraft sunucuları için rastgele mini oyunlar ve turnuvalar d�
 ## Kurulum
 1. Projeyi indirin veya derlenmiş jar dosyasını `plugins/` klasörüne yerleştirin.
 2. Eklenti **Spigot 1.21** veya daha yeni bir sürüm gerektirir. Sunucunuzu uygun sürümde başlatın.
-3. Spigot (veya türevi) sunucunuzu başlatın. İlk çalıştırmada `RandomEvents` klasöründe **config.yml** dosyası oluşacaktır.
-4. `config.yml` içindeki ayarları ihtiyaçlarınıza göre düzenleyin. Örnek yapılandırmanın ilk bölümü aşağıdadır:
+3. Spigot (veya türevi) sunucunuzu başlatın. İlk çalıştırmada `RandomEvents` klasöründe **config.yml** ve **license.yml** dosyaları oluşacaktır.
+4. `license.yml` dosyasındaki `license-key` alanına geçerli lisans anahtarınızı girin. Lisans doğrulanamazsa eklenti çalışmayacaktır.
+5. `config.yml` içindeki ayarları ihtiyaçlarınıza göre düzenleyin. Örnek yapılandırmanın ilk bölümü aşağıdadır:
 
 ```yml
 ##################################################################

--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -26,14 +26,14 @@ sourceSets {
         java.exclude 'com/immortalman01/randomevents/util/UtilsProtocolLib.java'
         java.exclude 'test/**'
         resources.srcDir '.'
-        resources.includes = ['plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml','scoreboard_tr.yml']
+        resources.includes = ['plugin.yml','config.yml','defaultConfig.yml','license.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml','scoreboard_tr.yml']
     }
 }
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from('.') {
-        include 'plugin.yml','config.yml','defaultConfig.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml','scoreboard_tr.yml'
+        include 'plugin.yml','config.yml','defaultConfig.yml','license.yml','messages.yml','messages_tr.yml','Luzverde2.nbs','luzverde.nbs','scoreboard.yml','scoreboard_tr.yml'
     }
 }
 

--- a/RandomEvents/license.yml
+++ b/RandomEvents/license.yml
@@ -1,0 +1,3 @@
+# License configuration for RandomEvents
+# Replace the placeholder with your valid LicenseGate key
+license-key: "PUT-YOUR-LICENSE-KEY-HERE"

--- a/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
@@ -60,6 +60,7 @@ import com.immortalman01.randomevents.util.NameTagHook;
 import com.immortalman01.randomevents.util.UtilsRandomEvents;
 import com.immortalman01.randomevents.util.UtilsSQL;
 import com.google.common.io.Files;
+import com.immortalman01.randomevents.license.LicenseVerifier;
 
 public class RandomEvents extends JavaPlugin {
 
@@ -125,14 +126,22 @@ public class RandomEvents extends JavaPlugin {
 	private static SimpleCommandMap scm;
 	private SimplePluginManager spm;
 	
-	private Logger logger;
+        private Logger logger;
 
-	public void onEnable() {
-		this.api = new API1711("%%__USER__%%", "RandomEvents");
-		this.lastCheck=new Date();
-		logger=getLogger();
-		logger.info("Loading config...");
-		loadConfig();
+        public void onEnable() {
+                this.api = new API1711("%%__USER__%%", "RandomEvents");
+                this.lastCheck=new Date();
+                logger=getLogger();
+                // Load and verify plugin license
+                Configuration licenseConfig = new Configuration(this, "license.yml");
+                String licenseKey = licenseConfig.getString("license-key");
+                if (licenseKey == null || licenseKey.isEmpty() || !LicenseVerifier.verify(this, licenseKey)) {
+                        logger.severe("License verification failed. Disabling plugin.");
+                        getServer().getPluginManager().disablePlugin(this);
+                        return;
+                }
+                logger.info("Loading config...");
+                loadConfig();
 		this.editando = new ArrayList<String>();
 		this.comandosExecutor = new ComandosExecutor();
 		this.cooldowns = new HashMap<String, Date>();

--- a/RandomEvents/src/com/immortalman01/randomevents/license/LicenseVerifier.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/license/LicenseVerifier.java
@@ -1,0 +1,51 @@
+package com.immortalman01.randomevents.license;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Simple license verification via DevLeoko LicenseGate service.
+ */
+public class LicenseVerifier {
+
+    private static final String API_KEY = "e9409d76-2006-455d-8c64-13b469845b64";
+    private static final String VERIFY_URL = "https://license.leoko.dev/api/verify";
+
+    /**
+     * Checks the given license key against the LicenseGate API.
+     *
+     * @param plugin      the plugin requesting verification
+     * @param licenseKey  the user provided license key
+     * @return true if the license is valid
+     */
+    public static boolean verify(JavaPlugin plugin, String licenseKey) {
+        try {
+            String query = VERIFY_URL + "?plugin=" +
+                    URLEncoder.encode(plugin.getName(), "UTF-8") +
+                    "&key=" + URLEncoder.encode(licenseKey, "UTF-8") +
+                    "&apiKey=" + URLEncoder.encode(API_KEY, "UTF-8");
+            URL url = new URL(query);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+            int code = conn.getResponseCode();
+            if (code != HttpURLConnection.HTTP_OK) {
+                plugin.getLogger().warning("License server responded with code " + code);
+                return false;
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+                String line = reader.readLine();
+                return line != null && line.trim().equalsIgnoreCase("VALID");
+            }
+        } catch (Exception e) {
+            plugin.getLogger().severe("License verification failed: " + e.getMessage());
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enforce license check with LicenseGate API
- include default `license.yml` for users to enter license key
- update README with installation instructions

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6858c0618f4083308ae00b909ec5c53b