### PR TITLE
Add LicenseGate verification

### DIFF
--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compileOnly 'net.citizensnpcs:citizens-main:2.0.33-SNAPSHOT'
     compileOnly 'commons-lang:commons-lang:2.6'
     compileOnly 'com.github.booksaw:BetterTeams:4.13.2'
+    implementation 'dev.respark.licensegate:license-gate:1.0.4'
     compileOnly project(':stubs')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:5.11.0'

--- a/RandomEvents/config.yml
+++ b/RandomEvents/config.yml
@@ -8,6 +8,9 @@ debugMode: false
 useEncoding: 'UTF-8'
 prefix: '&a&lRandomEvents &f&l>>'
 
+# License key required by LicenseGate
+licenseKey: ''
+
 ##################################################################
 ##						  GENERAL   							##
 ##################################################################

--- a/RandomEvents/defaultConfig.yml
+++ b/RandomEvents/defaultConfig.yml
@@ -8,6 +8,8 @@ debugMode: false
 useEncoding: 'UTF-8'
 prefix: '&a&lRandomEvents &f&l>>'
 language: 'en'
+# License key required by LicenseGate
+licenseKey: ''
 
 ##################################################################
 ##						  GENERAL   							##

--- a/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
@@ -60,6 +60,7 @@ import com.immortalman01.randomevents.util.NameTagHook;
 import com.immortalman01.randomevents.util.UtilsRandomEvents;
 import com.immortalman01.randomevents.util.UtilsSQL;
 import com.google.common.io.Files;
+import dev.respark.licensegate.LicenseGate;
 
 public class RandomEvents extends JavaPlugin {
 
@@ -125,18 +126,31 @@ public class RandomEvents extends JavaPlugin {
 	private static SimpleCommandMap scm;
 	private SimplePluginManager spm;
 	
-	private Logger logger;
+        private Logger logger;
 
-	public void onEnable() {
-		this.api = new API1711("%%__USER__%%", "RandomEvents");
-		this.lastCheck=new Date();
-		logger=getLogger();
-		logger.info("Loading config...");
-		loadConfig();
-		this.editando = new ArrayList<String>();
-		this.comandosExecutor = new ComandosExecutor();
-		this.cooldowns = new HashMap<String, Date>();
-		logger.info("Loading variables...");
+        private LicenseGate licenseGate;
+
+        public void onEnable() {
+                this.api = new API1711("%%__USER__%%", "RandomEvents");
+                this.lastCheck = new Date();
+                logger = getLogger();
+                logger.info("Loading config...");
+                loadConfig();
+
+                // Initialize LicenseGate and verify the provided license key
+                licenseGate = new LicenseGate("e9409d76-2006-455d-8c64-13b469845b64");
+                String key = getConfig().getString("licenseKey");
+                LicenseGate.ValidationType result = licenseGate.verify(key);
+                if (result != LicenseGate.ValidationType.VALID) {
+                        logger.severe("License verification failed: " + result);
+                        getServer().getPluginManager().disablePlugin(this);
+                        return;
+                }
+
+                this.editando = new ArrayList<String>();
+                this.comandosExecutor = new ComandosExecutor();
+                this.cooldowns = new HashMap<String, Date>();
+                logger.info("Loading variables...");
 
 		inicializaVariables();
 		

--- a/build.gradle
+++ b/build.gradle
@@ -16,5 +16,9 @@ subprojects {
         maven { url 'https://jitpack.io' }
         maven { url 'https://repo.minebench.de/' }
         maven { url 'https://repo.codemc.org/repository/maven-public/' }
+        maven {
+            name 'resparkReleases'
+            url 'https://maven.respark.dev/releases'
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add respark repo for LicenseGate
- depend on `license-gate` v1.0.4
- add `licenseKey` field to config files
- require license validation on plugin enable

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6858c2985dfc8330983a012637aee5c7