### PR TITLE
Fix teleport for all players after PAINTBALL_TOP_KILL

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -1313,6 +1313,15 @@ public class MatchActive {
                                 // Teleport winners back to spawn after rewards
                                 echaDePartida(player, false, true, true, false, false, false);
                         }
+
+                        // Ensure remaining players are also teleported to spawn
+                        List<Player> remaining = new ArrayList<Player>(getPlayerHandler().getPlayersObj());
+                        for (Player p : remaining) {
+                                if ((ganadores != null && ganadores.contains(p)) || specs.contains(p)) {
+                                        continue;
+                                }
+                                echaDePartida(p, false, true, true, false, false, false);
+                        }
 			if (getPlayerHandler().getPlayerContador() != null) {
 				UtilsRandomEvents.removeGlow(plugin, getPlayerHandler().getPlayerContador(),
 						getPlayerHandler().getPlayersTotalObj());


### PR DESCRIPTION
## Summary
- teleport every participant back to spawn at the end of Paintball Top Kill events

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_6859696483648330a37a336313219895