### PR TITLE
Fix kit removal via chat

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Chat.java
@@ -1040,7 +1040,7 @@ public class Chat implements Listener {
                                        case KITS:
                                                 try {
                                                         if (message.trim().startsWith("-")) {
-                                                                Integer remove = Integer.valueOf(message.trim().substring(1));
+                                                                Integer remove = Integer.valueOf(message.trim().substring(1).trim());
                                                                 if (remove > 0 && remove <= match.getKits().size()) {
                                                                         String kitName = match.getKits().remove(remove.intValue() - 1);
                                                                         plugin.getPlayersCreation().remove(player.getName());


### PR DESCRIPTION
## Summary
- handle whitespace when removing kits from a match

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68599286e3a4833092fc9420d530b8af