### PR TITLE
Add persistent event IDs

### DIFF
--- a/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/RandomEvents.java
@@ -119,7 +119,12 @@ public class RandomEvents extends JavaPlugin {
 
 	private NameTagHook nametagHook;
 
-	private Scoreboard colorBoard;
+        private Scoreboard colorBoard;
+
+        /**
+         * Next available unique identifier for newly created events.
+         */
+        private int nextMatchId = 1;
 
 	private CmdExecutor cmdExecutor;
 	private static SimpleCommandMap scm;
@@ -294,9 +299,9 @@ public class RandomEvents extends JavaPlugin {
 		getLogger().info(" Author immortalman01 - desactivado");
 	}
 
-	public void inicializaVariables() {
-		updateConfig();
-		this.playerMatches = new HashMap<String, Match>();
+        public void inicializaVariables() {
+                updateConfig();
+                this.playerMatches = new HashMap<String, Match>();
 		this.playersCreation = new HashMap<String, Integer>();
 		this.playerWaterDrop = new HashMap<String, WaterDropStep>();
 		this.playersCreationWaterDrop = new HashMap<String, Integer>();
@@ -306,6 +311,7 @@ public class RandomEvents extends JavaPlugin {
                 reventConfig = new ReventConfig(this);
                 reventConfig.inicializaVariables();
                 scoreboardConfig = new ScoreboardConfig(this);
+                this.nextMatchId = 1;
 
         }
 
@@ -747,9 +753,17 @@ public class RandomEvents extends JavaPlugin {
 		return colorBoard;
 	}
 
-	public void setColorBoard(Scoreboard colorBoard) {
-		this.colorBoard = colorBoard;
-	}
+        public void setColorBoard(Scoreboard colorBoard) {
+                this.colorBoard = colorBoard;
+        }
+
+        public int getNextMatchId() {
+                return nextMatchId;
+        }
+
+        public void setNextMatchId(int nextMatchId) {
+                this.nextMatchId = nextMatchId;
+        }
 
 	public CmdExecutor getCmdExecutor() {
 		return cmdExecutor;

--- a/RandomEvents/src/com/immortalman01/randomevents/commands/ComandosExecutor.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/commands/ComandosExecutor.java
@@ -290,7 +290,7 @@ public class ComandosExecutor {
 
 	public void deleteRandomEvent(RandomEvents plugin, Player player, String number) {
 		try {
-			Match match = plugin.getMatches().get(Integer.valueOf(number));
+                        Match match = UtilsRandomEvents.findMatchById(plugin, Integer.valueOf(number));
 			if (match != null) {
 				UtilsRandomEvents.borraMatch(plugin, match, player);
 			} else {
@@ -306,7 +306,7 @@ public class ComandosExecutor {
 
 	public void disableRandomEvent(RandomEvents plugin, Player player, String number) {
 		try {
-			Match match = plugin.getMatches().get(Integer.valueOf(number));
+                        Match match = UtilsRandomEvents.findMatchById(plugin, Integer.valueOf(number));
 			if (match != null) {
 				UtilsRandomEvents.disableMatch(plugin, match, player);
 			} else {
@@ -322,7 +322,7 @@ public class ComandosExecutor {
 
 	public void enableRandomEvent(RandomEvents plugin, Player player, String number) {
 		try {
-			Match match = plugin.getMatches().get(Integer.valueOf(number));
+                        Match match = UtilsRandomEvents.findMatchById(plugin, Integer.valueOf(number));
 			if (match != null) {
 				UtilsRandomEvents.enableMatch(plugin, match, player);
 			} else {
@@ -338,7 +338,7 @@ public class ComandosExecutor {
 
 	public void disableRandomEventSchedule(RandomEvents plugin, Player player, String number) {
 		try {
-			Match match = plugin.getMatches().get(Integer.valueOf(number));
+                        Match match = UtilsRandomEvents.findMatchById(plugin, Integer.valueOf(number));
 			if (match != null) {
 				UtilsRandomEvents.disableMatchSchedule(plugin, match, player);
 			} else {
@@ -354,7 +354,7 @@ public class ComandosExecutor {
 
 	public void enableRandomEventSchedule(RandomEvents plugin, Player player, String number) {
 		try {
-			Match match = plugin.getMatches().get(Integer.valueOf(number));
+                        Match match = UtilsRandomEvents.findMatchById(plugin, Integer.valueOf(number));
 			if (match != null) {
 				UtilsRandomEvents.enableMatchSchedule(plugin, match, player);
 			} else {
@@ -373,16 +373,16 @@ public class ComandosExecutor {
 		for (Match m : plugin.getMatches()) {
 			if (player != null) {
 
-				player.sendMessage(((m.getEnabled() == null || m.getEnabled()) ? "§6" : "§c") + "§l"
-						+ plugin.getMatches().indexOf(m) + " - " + m.getMinigame().getMessage(plugin) + " -> "
-						+ m.getName().replaceAll(" ", "_") + " ( Min: " + m.getAmountPlayersMin() + ", Max: "
-						+ m.getAmountPlayers() + ") "
-						+ ((m.getEnabledSchedule() == null || m.getEnabledSchedule()) ? "" : "§c(Schedule Disabled)"));
-			} else {
-				plugin.getLoggerP().info(plugin.getMatches().indexOf(m) + " - " + m.getMinigame().getMessage(plugin)
-						+ " -> " + m.getName().replaceAll(" ", "_") + " ( Min: " + m.getAmountPlayersMin() + ", Max: "
-						+ m.getAmountPlayers() + ") "
-						+ ((m.getEnabledSchedule() == null || m.getEnabledSchedule()) ? "" : "§c(Schedule Disabled)"));
+                                player.sendMessage(((m.getEnabled() == null || m.getEnabled()) ? "§6" : "§c") + "§l"
+                                                + m.getId() + " - " + m.getMinigame().getMessage(plugin) + " -> "
+                                                + m.getName().replaceAll(" ", "_") + " ( Min: " + m.getAmountPlayersMin() + ", Max: "
+                                                + m.getAmountPlayers() + ") "
+                                                + ((m.getEnabledSchedule() == null || m.getEnabledSchedule()) ? "" : "§c(Schedule Disabled)"));
+                        } else {
+                                plugin.getLoggerP().info(m.getId() + " - " + m.getMinigame().getMessage(plugin)
+                                                + " -> " + m.getName().replaceAll(" ", "_") + " ( Min: " + m.getAmountPlayersMin() + ", Max: "
+                                                + m.getAmountPlayers() + ") "
+                                                + ((m.getEnabledSchedule() == null || m.getEnabledSchedule()) ? "" : "§c(Schedule Disabled)"));
 			}
 		}
 
@@ -524,7 +524,7 @@ public class ComandosExecutor {
 		if (plugin.getMatchActive() == null) {
 			try {
 
-				Match m = plugin.getMatches().get(Integer.valueOf(number));
+                                Match m = UtilsRandomEvents.findMatchById(plugin, Integer.valueOf(number));
 				if (m.getEnabled() == null || m.getEnabled()) {
 					if (!plugin.getReventConfig().getNeedSpecificPermissionStartRevent()
 							|| player.hasPermission("randomevent.start." + UtilsRandomEvents.getMatchNameByMatch(m))) {
@@ -620,7 +620,7 @@ public class ComandosExecutor {
 	public void editRandomEvent(RandomEvents plugin, Player player, String number) {
 		try {
 
-			Match m = plugin.getMatches().get(Integer.valueOf(number));
+                        Match m = UtilsRandomEvents.findMatchById(plugin, Integer.valueOf(number));
 			plugin.getPlayerMatches().put(player.getName(), m);
 			plugin.getEditando().add(player.getName());
 			player.sendMessage(UtilsRandomEvents.enviaInfoCreacion(m, player, plugin));
@@ -634,7 +634,7 @@ public class ComandosExecutor {
 	public void tpRandomEvent(RandomEvents plugin, Player player, String number) {
 		try {
 
-			Match m = plugin.getMatches().get(Integer.valueOf(number));
+                        Match m = UtilsRandomEvents.findMatchById(plugin, Integer.valueOf(number));
 			if (m.getSpawns().isEmpty()) {
 				player.sendMessage(plugin.getLanguage().getTagPlugin() + plugin.getLanguage().getInvalidInput());
 
@@ -780,8 +780,12 @@ public class ComandosExecutor {
 	public void scheduleRandomEvent(RandomEvents plugin, Player player, String day, String hour, String minute,
 			String idMatch) {
 		try {
-			Schedule s = new Schedule(DayWeek.getByValues(day).getPosition(), Integer.valueOf(hour),
-					Integer.valueOf(minute), plugin.getMatches().get(Integer.valueOf(idMatch)).getName());
+                        Match selected = UtilsRandomEvents.findMatchById(plugin, Integer.valueOf(idMatch));
+                        if (selected == null) {
+                                throw new IllegalArgumentException();
+                        }
+                        Schedule s = new Schedule(DayWeek.getByValues(day).getPosition(), Integer.valueOf(hour),
+                                        Integer.valueOf(minute), selected.getName());
 
 			UtilsRandomEvents.terminaCreacionSchedule(plugin, player, s);
 

--- a/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/Match.java
@@ -15,9 +15,12 @@ import com.immortalman01.randomevents.match.utils.InventoryPers;
 
 public class Match implements Comparable<Match> {
 
-	private String name;
-	
-	private String permission;
+        private String name;
+
+        private String permission;
+
+        /** Unique identifier of the event. */
+        private Integer id;
 
 	private InventoryPers inventory;
 
@@ -703,9 +706,17 @@ public class Match implements Comparable<Match> {
 		return permission;
 	}
 
-	public void setPermission(String permission) {
-		this.permission = permission;
-	}
+        public void setPermission(String permission) {
+                this.permission = permission;
+        }
+
+        public Integer getId() {
+                return id;
+        }
+
+        public void setId(Integer id) {
+                this.id = id;
+        }
 
 	public List<String> getCommandsOnStart() {
 		return commandsOnStart;

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -168,7 +168,12 @@ public class UtilsRandomEvents {
                }
                if (match == null)
                        match = plugin.getPlayerMatches().get(player.getName());
-		try {
+
+               if (match.getId() == null) {
+                       match.setId(plugin.getNextMatchId());
+                       plugin.setNextMatchId(plugin.getNextMatchId() + 1);
+               }
+               try {
 			String json = UtilidadesJson.fromMatchToJSON(plugin, match);
 			if (json != null) {
                             File dataFolder = new File(plugin.getDataFolder(), "events");
@@ -1038,15 +1043,31 @@ public class UtilsRandomEvents {
 				Charset sc = Charset.forName(plugin.getReventConfig().getUseEncoding());
 
 				br = new BufferedReader(new InputStreamReader(fr, sc));
-				Match match = UtilidadesJson.fromJSONToMatch(plugin, br);
-				if (match != null) {
-					if (match.getInventory() != null) {
-						match = UtilsRandomEvents.convertInventoryToKits(plugin, match);
-						matchToConvert.add(match);
-					}
+                                Match match = UtilidadesJson.fromJSONToMatch(plugin, br);
+                                if (match != null) {
+                                        if (match.getId() == null) {
+                                                match.setId(plugin.getNextMatchId());
+                                                plugin.setNextMatchId(plugin.getNextMatchId() + 1);
+                                                try (PrintWriter pw = new PrintWriter(
+                                                                new OutputStreamWriter(new FileOutputStream(file, false),
+                                                                                Charset.forName(plugin.getReventConfig().getUseEncoding())))) {
+                                                        pw.println(UtilidadesJson.fromMatchToJSON(plugin, match));
+                                                } catch (Exception e) {
+                                                        plugin.getLoggerP().info(e.getMessage());
+                                                }
+                                        } else {
+                                                if (match.getId() >= plugin.getNextMatchId()) {
+                                                        plugin.setNextMatchId(match.getId() + 1);
+                                                }
+                                        }
 
-					listaPartidas.add(match);
-				}
+                                        if (match.getInventory() != null) {
+                                                match = UtilsRandomEvents.convertInventoryToKits(plugin, match);
+                                                matchToConvert.add(match);
+                                        }
+
+                                        listaPartidas.add(match);
+                                }
 
 			} catch (FileNotFoundException e) {
 				plugin.getLoggerP().info(e.getMessage());
@@ -1613,15 +1634,34 @@ public class UtilsRandomEvents {
 		return result;
 	}
 
-	public static Match findMatch(RandomEvents plugin, String matchName) {
-		Match m = null;
-		for (Match match : plugin.getMatches()) {
-			if (match.getName().equals(matchName)) {
-				m = match;
-			}
-		}
-		return m;
-	}
+        public static Match findMatch(RandomEvents plugin, String matchName) {
+                Match m = null;
+                for (Match match : plugin.getMatches()) {
+                        if (match.getName().equals(matchName)) {
+                                m = match;
+                        }
+                }
+                return m;
+        }
+
+        /**
+         * Locate a match by its unique identifier.
+         *
+         * @param plugin the plugin instance
+         * @param id     the match id
+         * @return the match or {@code null} if not found
+         */
+        public static Match findMatchById(RandomEvents plugin, Integer id) {
+                if (id == null) {
+                        return null;
+                }
+                for (Match match : plugin.getMatches()) {
+                        if (id.equals(match.getId())) {
+                                return match;
+                        }
+                }
+                return null;
+        }
 
 	public static Location getRandomLocation(RandomEvents plugin, Cuboid cuboid, MatchActive matchActive) {
 		Integer difX = Double.valueOf(cuboid.getMaxX()).intValue() - Double.valueOf(cuboid.getMinX()).intValue();


### PR DESCRIPTION
## Summary
- assign a unique `id` to every event `Match`
- persist and increment IDs when loading or creating events
- track the next available ID in `RandomEvents`
- lookup events by `id` instead of list index
- display event IDs in `/revent list`

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_6859da5b09a08330902d670b6ae084dd