### PR TITLE
Add 1.20 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RandomEvents, Minecraft sunucuları için rastgele mini oyunlar ve turnuvalar d�
 
 ## Kurulum
 1. Projeyi indirin veya derlenmiş jar dosyasını `plugins/` klasörüne yerleştirin.
-2. Eklenti **Spigot 1.21** veya daha yeni bir sürüm gerektirir. Sunucunuzu uygun sürümde başlatın.
+2. Eklenti **Spigot 1.20** veya daha yeni bir sürüm gerektirir. Sunucunuzu uygun sürümde başlatın.
 3. Spigot (veya türevi) sunucunuzu başlatın. İlk çalıştırmada `RandomEvents` klasöründe **config.yml** dosyası oluşacaktır.
 4. `config.yml` içindeki ayarları ihtiyaçlarınıza göre düzenleyin. Örnek yapılandırmanın ilk bölümü aşağıdadır:
 
@@ -59,7 +59,7 @@ Komutlar `plugin.yml` dosyasında tanımlanmıştır ve diğer bazı eklentiler 
 name: RandomEvents
 main: com.immortalman01.randomevents.RandomEvents
 version: 2.9.5
-api-version: 1.21
+api-version: 1.20
 # Removed hard dependency on Lib1711 as the required
 # functionality is now bundled directly with the plugin
 softdepend: [CrackShot, PlaceholderAPI, WorldEdit, WorldGuard, Multiworld, Multiverse-Core, NametagEdit, LibsDisguises, NoteBlockAPI, Citizens]

--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -7,7 +7,7 @@ version = '2.9.5'
 
 dependencies {
     // Match the API version declared in plugin.yml
-    compileOnly 'org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
     compileOnly 'com.zaxxer:HikariCP:4.0.3'
     compileOnly 'com.github.koca2000:NoteBlockAPI:1.5.0'
     compileOnly 'com.github.PlaceholderAPI:PlaceholderAPI:2.11.3'
@@ -17,7 +17,7 @@ dependencies {
     compileOnly project(':stubs')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:5.11.0'
-    testImplementation 'org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT'
+    testImplementation 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
 }
 
 sourceSets {

--- a/RandomEvents/plugin.yml
+++ b/RandomEvents/plugin.yml
@@ -1,7 +1,7 @@
 name: RandomEvents
 main: com.immortalman01.randomevents.RandomEvents
 version: 2.9.5
-api-version: 1.21
+api-version: 1.20
 # Removed hard dependency on Lib1711 as the required
 # functionality is now bundled directly with the plugin
 softdepend: [CrackShot, PlaceholderAPI, WorldEdit, WorldGuard, Multiworld, Multiverse-Core, NametagEdit, LibsDisguises, NoteBlockAPI, Citizens, BetterTeams]

--- a/RandomEvents_Quests/build.gradle
+++ b/RandomEvents_Quests/build.gradle
@@ -7,7 +7,7 @@ version = '1.1'
 
 dependencies {
     // Match the API version declared in plugin.yml
-    compileOnly 'org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
     compileOnly 'com.github.PikaMug:Quests:5.2.3'
     compileOnly project(':RandomEvents')
     compileOnly project(':stubs')

--- a/RandomEvents_Quests/plugin.yml
+++ b/RandomEvents_Quests/plugin.yml
@@ -1,5 +1,5 @@
 name: RandomEventsQuests
 main: com.immortalman01.randomeventsquests.RandomEventsQuests
 version: 1.1
-api-version: 1.21
+api-version: 1.20
 depend: [Quests,RandomEvents]


### PR DESCRIPTION
## Summary
- compile against Spigot 1.20.4
- update plugin descriptors to 1.20 API
- update README to mention 1.20 support

## Testing
- `gradle test` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686091a53fc48330b067f4718322bbca