### PR TITLE
Add compatibility for Spigot 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RandomEvents, Minecraft sunucuları için rastgele mini oyunlar ve turnuvalar d�
 
 ## Kurulum
 1. Projeyi indirin veya derlenmiş jar dosyasını `plugins/` klasörüne yerleştirin.
-2. Eklenti **Spigot 1.20** veya daha yeni bir sürüm gerektirir. Sunucunuzu uygun sürümde başlatın.
+2. Eklenti **Spigot 1.20** ve **Spigot 1.21** sürümleriyle uyumludur. Sunucunuzu uygun sürümde başlatın.
 3. Spigot (veya türevi) sunucunuzu başlatın. İlk çalıştırmada `RandomEvents` klasöründe **config.yml** dosyası oluşacaktır.
 4. `config.yml` içindeki ayarları ihtiyaçlarınıza göre düzenleyin. Örnek yapılandırmanın ilk bölümü aşağıdadır:
 

--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -7,7 +7,7 @@ version = '2.9.5'
 
 dependencies {
     // Match the API version declared in plugin.yml
-    compileOnly 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.21.6-R0.1-SNAPSHOT'
     compileOnly 'com.zaxxer:HikariCP:4.0.3'
     compileOnly 'com.github.koca2000:NoteBlockAPI:1.5.0'
     compileOnly 'com.github.PlaceholderAPI:PlaceholderAPI:2.11.3'
@@ -17,7 +17,7 @@ dependencies {
     compileOnly project(':stubs')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:5.11.0'
-    testImplementation 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
+    testImplementation 'org.spigotmc:spigot-api:1.21.6-R0.1-SNAPSHOT'
 }
 
 sourceSets {

--- a/RandomEvents/src/com/immortalman01/randomevents/commands/ComandosExecutor.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/commands/ComandosExecutor.java
@@ -12,6 +12,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import com.immortalman01.randomevents.util.CompatibilityUtils;
 
 import com.immortalman01.randomevents.RandomEvents;
 import com.immortalman01.randomevents.api.events.ReventSpawnEvent;
@@ -743,7 +744,9 @@ public class ComandosExecutor {
 						UtilsRandomEvents.teleportaPlayer(player,
 								plugin.getMatchActive().getMapHandler().getCheckpoints().get(player.getName()), plugin);
                                                 if (plugin.getReventConfig().getRaceSlowEffect())
-                                                        player.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 60, 99));
+                                                player.addPotionEffect(new PotionEffect(
+                                                                CompatibilityUtils.getPotionEffect("SLOWNESS", "SLOW"),
+                                                                60, 99));
 
 					}
 				} else {

--- a/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/listeners/Use.java
@@ -60,6 +60,7 @@ import com.immortalman01.randomevents.match.enums.MinigameType;
 import com.immortalman01.randomevents.match.enums.Petos;
 import com.immortalman01.randomevents.util.Constantes;
 import com.immortalman01.randomevents.util.UtilsRandomEvents;
+import com.immortalman01.randomevents.util.CompatibilityUtils;
 import com.immortalman01.util.enums.Particle1711;
 import com.immortalman01.util.enums.ParticleDisplay;
 import com.immortalman01.util.enums.XMaterial;
@@ -220,7 +221,9 @@ public class Use implements Listener {
 								player.getInventory().remove(player.getInventory().getItemInMainHand());
 								player.updateInventory();
 							}
-                                                        player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, 60, 5));
+                                                        player.addPotionEffect(new PotionEffect(
+                                                                        CompatibilityUtils.getPotionEffect("RESISTANCE", "DAMAGE_RESISTANCE"),
+                                                                        60, 5));
 							player.sendMessage(
 									plugin.getLanguage().getTagPlugin() + plugin.getLanguage().getNowProtected());
 						} else if (player.getInventory().getItemInMainHand().equals(plugin.getReventConfig().getCheckpointItem())) {
@@ -230,7 +233,9 @@ public class Use implements Listener {
 									plugin.getMatchActive().getMapHandler().getCheckpoints().get(player.getName()),
 									plugin);
                                                         if(plugin.getReventConfig().getRaceSlowEffect())
-            player.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 60, 99));
+            player.addPotionEffect(new PotionEffect(
+                            CompatibilityUtils.getPotionEffect("SLOWNESS", "SLOW"),
+                            60, 99));
 
 						} else if (player.getInventory().getItemInMainHand().equals(plugin.getReventConfig().getEndVanishItem())) {
 							evt.setCancelled(true);

--- a/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/match/MatchActive.java
@@ -37,6 +37,7 @@ import org.bukkit.entity.Horse;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.TNTPrimed;
+import com.immortalman01.randomevents.util.CompatibilityUtils;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.block.data.BlockData;
@@ -1982,7 +1983,9 @@ public class MatchActive {
 
                         }
                         initializeSnowballAmmo();
-                        PotionEffect pot = new PotionEffect(PotionEffectType.HASTE, 240, 99);
+                        PotionEffect pot = new PotionEffect(
+                                        CompatibilityUtils.getPotionEffect("HASTE", "FAST_DIGGING"),
+                                        240, 99);
 			UtilsRandomEvents.applyPotionEffects(pot, getPlayerHandler().getPlayersObj());
 
 			task = new BukkitRunnable() {
@@ -2527,16 +2530,16 @@ public class MatchActive {
 			for (Player p : getPlayerHandler().getPlayersObj()) {
 				iniciaPlayer(p);
 
-				Boat boat = null;
-				if (getMatch().getEntitySpawns() == null || getMatch().getEntitySpawns().isEmpty()) {
-					boat = (Boat) p.getWorld().spawnEntity(p.getLocation(), EntityType.BOAT);
-					boat.setPassenger(p);
+                                Boat boat = null;
+                                if (getMatch().getEntitySpawns() == null || getMatch().getEntitySpawns().isEmpty()) {
+                                        boat = (Boat) p.getWorld().spawnEntity(p.getLocation(), CompatibilityUtils.getBoatEntity());
+                                        boat.setPassenger(p);
 
-				} else {
-					boat = (Boat) p.getWorld().spawnEntity(
-							match.getEntitySpawns().get(getPlayerHandler().getPlayersObj().indexOf(p)),
-							EntityType.BOAT);
-				}
+                                } else {
+                                        boat = (Boat) p.getWorld().spawnEntity(
+                                                        match.getEntitySpawns().get(getPlayerHandler().getPlayersObj().indexOf(p)),
+                                                        CompatibilityUtils.getBoatEntity());
+                                }
 
 				getMobs().add(boat);
 				getPets().put(p.getName(), boat);
@@ -4247,7 +4250,9 @@ public class MatchActive {
 				removePotionsEffects(p);
 			}
 
-                        p.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE, 20, 2));
+                        p.addPotionEffect(new PotionEffect(
+                                        CompatibilityUtils.getPotionEffect("RESISTANCE", "DAMAGE_RESISTANCE"),
+                                        20, 2));
 
                         if (match.getMinigame() == MinigameType.PAINTBALL_TOP_KILL) {
                                 p.getInventory().setItem(8, getKillCoinItem(p));

--- a/RandomEvents/src/com/immortalman01/randomevents/util/CompatibilityUtils.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/CompatibilityUtils.java
@@ -1,0 +1,64 @@
+package com.immortalman01.randomevents.util;
+
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.potion.PotionEffectType;
+
+public class CompatibilityUtils {
+    /**
+     * Determine the correct boat entity type for the current server version.
+     * <p>
+     * Spigot 1.20 exposes the generic {@code EntityType.BOAT} constant which was
+     * removed in 1.21 in favour of material-specific boat types. This method
+     * attempts to use the generic constant when available and falls back to
+     * {@code OAK_BOAT} for newer versions.
+     */
+    public static EntityType getBoatEntity() {
+        try {
+            return EntityType.valueOf("BOAT");
+        } catch (IllegalArgumentException ex) {
+            // 1.21 and newer no longer provide the BOAT constant
+            return EntityType.valueOf("OAK_BOAT");
+        }
+    }
+
+    /**
+     * Resolve an EntityType that may have been renamed between versions.
+     * @param modern the name in 1.21+
+     * @param legacy the name in 1.20
+     * @return the EntityType constant if available
+     */
+    public static EntityType getEntityType(String modern, String legacy) {
+        try {
+            return EntityType.valueOf(modern);
+        } catch (IllegalArgumentException ex) {
+            return EntityType.valueOf(legacy);
+        }
+    }
+
+    /**
+     * Resolve a potion effect type that was renamed in 1.21.
+     * @param modernName the enum constant used in 1.21 and newer
+     * @param legacyName the enum constant used in 1.20 and older
+     * @return the resolved PotionEffectType
+     */
+    public static PotionEffectType getPotionEffect(String modernName, String legacyName) {
+        PotionEffectType type = PotionEffectType.getByName(modernName);
+        if (type == null) {
+            type = PotionEffectType.getByName(legacyName);
+        }
+        return type;
+    }
+
+    /**
+     * Obtain the additional tooltip flag if present (1.21+).
+     * Returns {@code null} when running on older versions.
+     */
+    public static ItemFlag getHideAdditionalTooltipFlag() {
+        try {
+            return ItemFlag.valueOf("HIDE_ADDITIONAL_TOOLTIP");
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+}

--- a/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
+++ b/RandomEvents/src/com/immortalman01/randomevents/util/UtilsRandomEvents.java
@@ -60,6 +60,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.util.Vector;
+import com.immortalman01.randomevents.util.CompatibilityUtils;
 
 import com.immortalman01.randomevents.RandomEvents;
 import com.immortalman01.randomevents.match.Kit;
@@ -1314,7 +1315,9 @@ public class UtilsRandomEvents {
         // p.sendMessage(message);
 
 	public static void tiraCohete(Location l) {
-                Firework fw = (Firework) l.getWorld().spawnEntity(l, EntityType.FIREWORK_ROCKET);
+                Firework fw = (Firework) l.getWorld().spawnEntity(
+                                l,
+                                CompatibilityUtils.getEntityType("FIREWORK_ROCKET", "FIREWORK"));
 		FireworkMeta fwm = fw.getFireworkMeta();
 
 		Random r = new Random();
@@ -1864,7 +1867,8 @@ public class UtilsRandomEvents {
 				itemMeta.setLore(lore);
 
                                 itemMeta.getItemFlags().add(ItemFlag.HIDE_ATTRIBUTES);
-                                itemMeta.getItemFlags().add(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+                                ItemFlag flag = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                                if (flag != null) itemMeta.getItemFlags().add(flag);
                                 itemMeta.getItemFlags().add(ItemFlag.HIDE_ENCHANTS);
 
 				item.setItemMeta(itemMeta);
@@ -1904,7 +1908,8 @@ public class UtilsRandomEvents {
 			lore.add(plugin.getLanguage().getStatsWinsRatio() + ratio.toPlainString());
 			itemMeta.setLore(lore);
                         itemMeta.getItemFlags().add(ItemFlag.HIDE_ATTRIBUTES);
-                        itemMeta.getItemFlags().add(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+                        ItemFlag flag2 = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                        if (flag2 != null) itemMeta.getItemFlags().add(flag2);
                         itemMeta.getItemFlags().add(ItemFlag.HIDE_ENCHANTS);
 			item.setItemMeta(itemMeta);
 			inv.setItem(position, item);
@@ -3810,7 +3815,8 @@ public class UtilsRandomEvents {
 			}
 			cabezaMeta.setLore(lore);
                         cabezaMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-                        cabezaMeta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+                        ItemFlag flag3 = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                        if (flag3 != null) cabezaMeta.addItemFlags(flag3);
                         cabezaMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
 			cabeza.setItemMeta(cabezaMeta);
 			inv.setItem(i - (page * 36), cabeza);
@@ -3863,7 +3869,8 @@ public class UtilsRandomEvents {
 					cabezaMeta.setLore(plugin.getLanguage().getKitDefaultLore());
 				}
                                 cabezaMeta.getItemFlags().add(ItemFlag.HIDE_ATTRIBUTES);
-                                cabezaMeta.getItemFlags().add(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+                                ItemFlag flag4 = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                                if (flag4 != null) cabezaMeta.getItemFlags().add(flag4);
                                 cabezaMeta.getItemFlags().add(ItemFlag.HIDE_ENCHANTS);
 
 				cabeza.setItemMeta(cabezaMeta);
@@ -3912,9 +3919,10 @@ public class UtilsRandomEvents {
 
 				cabezaMeta.setLore(lore);
 
-                                cabezaMeta.getItemFlags().add(ItemFlag.HIDE_ATTRIBUTES);
-                                cabezaMeta.getItemFlags().add(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
-                                cabezaMeta.getItemFlags().add(ItemFlag.HIDE_ENCHANTS);
+                cabezaMeta.getItemFlags().add(ItemFlag.HIDE_ATTRIBUTES);
+                ItemFlag flag5 = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                if (flag5 != null) cabezaMeta.getItemFlags().add(flag5);
+                cabezaMeta.getItemFlags().add(ItemFlag.HIDE_ENCHANTS);
 				cabeza.setItemMeta(cabezaMeta);
 				inv.setItem(i, cabeza);
 			}
@@ -3931,7 +3939,8 @@ public class UtilsRandomEvents {
                 meta.setDisplayName(plugin.getLanguage().getKillcoinsMoreSnowballsName());
                 meta.setLore(plugin.getLanguage().getKillcoinsMoreSnowballsLore());
                 meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-                meta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+                ItemFlag flag6 = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                if (flag6 != null) meta.addItemFlags(flag6);
                 meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
                 snow.setItemMeta(meta);
                 inv.setItem(4, snow);
@@ -3941,7 +3950,8 @@ public class UtilsRandomEvents {
                 metaT.setDisplayName(plugin.getLanguage().getKillcoinsTripleShootName());
                 metaT.setLore(plugin.getLanguage().getKillcoinsTripleShootLore());
                 metaT.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-                metaT.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+                ItemFlag flag7 = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                if (flag7 != null) metaT.addItemFlags(flag7);
                 metaT.addItemFlags(ItemFlag.HIDE_ENCHANTS);
                 triple.setItemMeta(metaT);
                 inv.setItem(5, triple);
@@ -3951,7 +3961,8 @@ public class UtilsRandomEvents {
                 metaS.setDisplayName(plugin.getLanguage().getKillcoinsStrongArmName());
                 metaS.setLore(plugin.getLanguage().getKillcoinsStrongArmLore());
                 metaS.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-                metaS.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+                ItemFlag flag8 = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                if (flag8 != null) metaS.addItemFlags(flag8);
                 metaS.addItemFlags(ItemFlag.HIDE_ENCHANTS);
                 strong.setItemMeta(metaS);
                 inv.setItem(6, strong);
@@ -3961,7 +3972,8 @@ public class UtilsRandomEvents {
                 metaL.setDisplayName(plugin.getLanguage().getKillcoinsAddLivesName());
                 metaL.setLore(plugin.getLanguage().getKillcoinsAddLivesLore());
                 metaL.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-                metaL.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+                ItemFlag flag9 = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                if (flag9 != null) metaL.addItemFlags(flag9);
                 metaL.addItemFlags(ItemFlag.HIDE_ENCHANTS);
                 lives.setItemMeta(metaL);
                 inv.setItem(7, lives);
@@ -3971,7 +3983,8 @@ public class UtilsRandomEvents {
                 metaF.setDisplayName(plugin.getLanguage().getKillcoinsFuryModeName());
                 metaF.setLore(plugin.getLanguage().getKillcoinsFuryModeLore());
                 metaF.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-                metaF.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+                ItemFlag flag10 = CompatibilityUtils.getHideAdditionalTooltipFlag();
+                if (flag10 != null) metaF.addItemFlags(flag10);
                 metaF.addItemFlags(ItemFlag.HIDE_ENCHANTS);
                 fury.setItemMeta(metaF);
                 inv.setItem(8, fury);
@@ -4211,8 +4224,9 @@ Integer probabilidad = parseProbability(trozosComandos[1]);
 
 	public static void invinciblePlayer(Player player, RandomEvents plugin) {
 		if (plugin.getReventConfig().getInvincibleAfterGame() > 0) {
-                        player.addPotionEffect(new PotionEffect(PotionEffectType.RESISTANCE,
-                                        plugin.getReventConfig().getInvincibleAfterGame(), 20));
+                player.addPotionEffect(new PotionEffect(
+                                CompatibilityUtils.getPotionEffect("RESISTANCE", "DAMAGE_RESISTANCE"),
+                                plugin.getReventConfig().getInvincibleAfterGame(), 20));
 		}
 
 	}

--- a/RandomEvents_Quests/build.gradle
+++ b/RandomEvents_Quests/build.gradle
@@ -7,7 +7,7 @@ version = '1.1'
 
 dependencies {
     // Match the API version declared in plugin.yml
-    compileOnly 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.21.6-R0.1-SNAPSHOT'
     compileOnly 'com.github.PikaMug:Quests:5.2.3'
     compileOnly project(':RandomEvents')
     compileOnly project(':stubs')


### PR DESCRIPTION
## Summary
- add `CompatibilityUtils` for handling version differences
- spawn boats using compatibility method
- resolve renamed potions, entity types and item flags for cross-version
- document support for Spigot 1.20 and 1.21

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_686093e8224083308489ad58ddeced80