### PR TITLE
Add Spigot 1.20.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RandomEvents, Minecraft sunucuları için rastgele mini oyunlar ve turnuvalar d�
 
 ## Kurulum
 1. Projeyi indirin veya derlenmiş jar dosyasını `plugins/` klasörüne yerleştirin.
-2. Eklenti **Spigot 1.20** ve **Spigot 1.21** sürümleriyle uyumludur. Sunucunuzu uygun sürümde başlatın.
+2. Eklenti **Spigot 1.20.X** ve **Spigot 1.21.X** sürümleriyle uyumludur. Sunucunuzu uygun sürümde başlatın.
 3. Spigot (veya türevi) sunucunuzu başlatın. İlk çalıştırmada `RandomEvents` klasöründe **config.yml** dosyası oluşacaktır.
 4. `config.yml` içindeki ayarları ihtiyaçlarınıza göre düzenleyin. Örnek yapılandırmanın ilk bölümü aşağıdadır:
 

--- a/RandomEvents/build.gradle
+++ b/RandomEvents/build.gradle
@@ -7,7 +7,7 @@ version = '2.9.5'
 
 dependencies {
     // Match the API version declared in plugin.yml
-    compileOnly 'org.spigotmc:spigot-api:1.21.6-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
     compileOnly 'com.zaxxer:HikariCP:4.0.3'
     compileOnly 'com.github.koca2000:NoteBlockAPI:1.5.0'
     compileOnly 'com.github.PlaceholderAPI:PlaceholderAPI:2.11.3'
@@ -17,7 +17,7 @@ dependencies {
     compileOnly project(':stubs')
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.mockito:mockito-core:5.11.0'
-    testImplementation 'org.spigotmc:spigot-api:1.21.6-R0.1-SNAPSHOT'
+    testImplementation 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
 }
 
 sourceSets {

--- a/RandomEvents_Quests/build.gradle
+++ b/RandomEvents_Quests/build.gradle
@@ -7,7 +7,7 @@ version = '1.1'
 
 dependencies {
     // Match the API version declared in plugin.yml
-    compileOnly 'org.spigotmc:spigot-api:1.21.6-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
     compileOnly 'com.github.PikaMug:Quests:5.2.3'
     compileOnly project(':RandomEvents')
     compileOnly project(':stubs')


### PR DESCRIPTION
## Summary
- support both 1.20.x and 1.21.x Spigot versions
- compile plugin and quests module against Spigot 1.20.4
- document multi-version compatibility in README

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68896021d3a083309cacad7eab44f48d